### PR TITLE
Implement loading a single plugin archive

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/ExtensionFinder.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/ExtensionFinder.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012 Decebal Suiu
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with
  * the License. You may obtain a copy of the License in the LICENSE file, or at:
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -20,5 +20,7 @@ import java.util.List;
 public interface ExtensionFinder {
 
 	public <T> List<ExtensionWrapper<T>> find(Class<T> type);
-	
+
+	public void reset();
+
 }

--- a/pf4j/src/main/java/ro/fortsoft/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/PluginManager.java
@@ -12,6 +12,7 @@
  */
 package ro.fortsoft.pf4j;
 
+import java.io.File;
 import java.util.List;
 
 /**
@@ -46,6 +47,14 @@ public interface PluginManager {
      * Load plugins.
      */
     public void loadPlugins();
+
+    /**
+     * Load a plugin.
+     *
+     * @param pluginArchiveFile
+     * @return the pluginId of the installed plugin or null
+     */
+	public String loadPlugin(File pluginArchiveFile);
 
     /**
      * Start all active plugins.


### PR DESCRIPTION
This pull request includes the extension finder reset enhancement.  The plugin manager is now able to load and unload a single plugin properly (tested with Gitblit).

This is a simplified implementation which does not account for resolving dependencies.  I tried using your existing resolve method, but that actually discards previous state.

It's a good starting point for simple plugins, but will no doubt need refinement.

I'm noting that your Eclipse is not configured to trim trailing whitespace which is partly why my diff looks large.  Looks like there is a line-ending difference too.  Sorry about that.
