### PR TITLE
Allow inspection of disabled plugins by not stopping resource loading

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/PluginClassLoader.java
@@ -12,11 +12,8 @@
  */
 package ro.fortsoft.pf4j;
 
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 
 /**
@@ -93,27 +90,4 @@ public class PluginClassLoader extends URLClassLoader {
         // use the standard URLClassLoader (which follows normal parent delegation)
         return super.loadClass(className);
     }
-
-    @Override
-    public URL getResource(String name) {
-        if (PluginState.DISABLED == getPlugin().getPluginState()) {
-            return null;
-        }
-
-        return super.getResource(name);
-    }
-
-    @Override
-    public Enumeration<URL> getResources(String name) throws IOException {
-        if (PluginState.DISABLED == getPlugin().getPluginState()) {
-            return Collections.emptyEnumeration();
-        }
-
-        return super.getResources(name);
-    }
-
-    private PluginWrapper getPlugin() {
-        return pluginManager.getPlugin(pluginDescriptor.getPluginId());
-    }
-
 }


### PR DESCRIPTION
The differences between a DISABLED plugin and a STARTED plugin are:
1. a STARTED plugin has executed Plugin.start(), a DISABLED plugin has not
2. a STARTED plugin may contribute extension instances, a DISABLED plugin may not

DISABLED plugins still have valid classloaders and their classes can be manually
loaded and explored, but the resource loading - which is important for inspection
has been handicapped by the DISABLED check.

Instead of preventing loading the extension indexes for DISABLED plugins, the
extension finder should only return ExtensionWrappers for STARTED plugins.
