### PR TITLE
Allow a plugin to setup an extension

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultExtensionFinder.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultExtensionFinder.java
@@ -71,6 +71,7 @@ public class DefaultExtensionFinder implements ExtensionFinder, PluginStateListe
                     if (type.isAssignableFrom(extensionType)) {
                         Object instance = extensionFactory.create(extensionType);
                         if (instance != null) {
+                            pluginWrapper.getPlugin().setupExtension(instance);
                             Extension extension = extensionType.getAnnotation(Extension.class);
                             log.debug("Added extension '{}' with ordinal {}", extensionType.getName(), extension.ordinal());
                             result.add(new ExtensionWrapper<T>(type.cast(instance), extension.ordinal()));

--- a/pf4j/src/main/java/ro/fortsoft/pf4j/Plugin.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/Plugin.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2012 Decebal Suiu
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this work except in compliance with
  * the License. You may obtain a copy of the License in the LICENSE file, or at:
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -65,4 +65,12 @@ public abstract class Plugin {
     public void stop() throws PluginException {
     }
 
+
+    /**
+     * Allow a plugin to setup an extension instance.
+     *
+     * @param extension
+     */
+    public void setupExtension(Object extension) {
+    }
 }


### PR DESCRIPTION
Give the plugin singleton instance an opportunity to setup or configure
an extension instance.  This may be useful if the pf4j consumer does not
use dependency injection.
