### PR TITLE
plugin verification info should be keeped

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -424,6 +424,13 @@ public abstract class AbstractPluginManager implements PluginManager {
         checkPluginId(pluginId);
 
         PluginWrapper pluginWrapper = getPlugin(pluginId);
+        try {
+            URLClassLoader loader = (URLClassLoader) pluginWrapper.getPluginClassLoader();
+            System.out.println(loader.getURLs().length);
+            loader.close();
+        } catch (Exception e){
+            e.printStackTrace();
+        }
         PluginDescriptor pluginDescriptor = pluginWrapper.getDescriptor();
         PluginState pluginState = pluginWrapper.getPluginState();
         if (PluginState.STOPPED == pluginState) {

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -744,13 +744,14 @@ public abstract class AbstractPluginManager implements PluginManager {
 
         PluginDescriptor pluginDescriptor = pluginWrapper.getDescriptor();
         if (systemVersion.equals("0.0.0") || versionManager.checkVersionConstraint(systemVersion, requires)) {
-            PluginClassLoader pluginClassLoaderLoader = (PluginClassLoader)pluginWrapper.getPluginClassLoader();
             try{
+                PluginClassLoader pluginClassLoaderLoader = (PluginClassLoader)pluginWrapper.getPluginClassLoader();
                 pluginClassLoaderLoader.loadClass(pluginDescriptor.getPluginClass());
-            } catch (ClassNotFoundException e){
+            } catch (ClassNotFoundException e) {
                 log.warn("Plugin '{}' main class '{}' not found",
-                    getPluginLabel(pluginDescriptor),pluginDescriptor.getPluginClass());
+                    getPluginLabel(pluginDescriptor), pluginDescriptor.getPluginClass());
                 return false;
+            } catch (ClassCastException e){
             }
             return true;
         }

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -390,13 +390,6 @@ public abstract class AbstractPluginManager implements PluginManager {
         while (itr.hasNext()) {
             PluginWrapper pluginWrapper = itr.next();
             PluginState pluginState = pluginWrapper.getPluginState();
-            try {
-                URLClassLoader loader = (URLClassLoader) pluginWrapper.getPluginClassLoader();
-                System.out.println(loader.getURLs().length);
-                loader.close();
-            } catch (Exception e){
-                e.printStackTrace();
-            }
             if (PluginState.STARTED == pluginState) {
                 try {
                     log.info("Stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
@@ -424,13 +417,6 @@ public abstract class AbstractPluginManager implements PluginManager {
         checkPluginId(pluginId);
 
         PluginWrapper pluginWrapper = getPlugin(pluginId);
-        try {
-            URLClassLoader loader = (URLClassLoader) pluginWrapper.getPluginClassLoader();
-            System.out.println(loader.getURLs().length);
-            loader.close();
-        } catch (Exception e){
-            e.printStackTrace();
-        }
         PluginDescriptor pluginDescriptor = pluginWrapper.getDescriptor();
         PluginState pluginState = pluginWrapper.getPluginState();
         if (PluginState.STOPPED == pluginState) {

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -21,6 +21,7 @@ import org.pf4j.util.StringUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -389,6 +390,13 @@ public abstract class AbstractPluginManager implements PluginManager {
         while (itr.hasNext()) {
             PluginWrapper pluginWrapper = itr.next();
             PluginState pluginState = pluginWrapper.getPluginState();
+            try {
+                URLClassLoader loader = (URLClassLoader) pluginWrapper.getPluginClassLoader();
+                System.out.println(loader.getURLs().length);
+                loader.close();
+            } catch (Exception e){
+                e.printStackTrace();
+            }
             if (PluginState.STARTED == pluginState) {
                 try {
                     log.info("Stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -21,7 +21,6 @@ import org.pf4j.util.StringUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/pf4j/src/main/java/org/pf4j/ManifestPluginDescriptorFinder.java
+++ b/pf4j/src/main/java/org/pf4j/ManifestPluginDescriptorFinder.java
@@ -51,8 +51,8 @@ public class ManifestPluginDescriptorFinder implements PluginDescriptorFinder {
 
     protected Manifest readManifest(Path pluginPath) throws PluginException {
         if (FileUtils.isJarFile(pluginPath)) {
-            try {
-                Manifest manifest = new JarFile(pluginPath.toFile()).getManifest();
+            try(JarFile jar = new JarFile(pluginPath.toFile())) {
+                Manifest manifest = jar.getManifest();
                 if (manifest != null) {
                     return manifest;
                 }


### PR DESCRIPTION
If a plugin disabled by [plugin verification](https://github.com/decebals/pf4j/blob/master/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java#L738), the ```DISABLED``` state shoud be keeped.

