### PR TITLE
Fixes #206

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -694,8 +694,6 @@ public abstract class AbstractPluginManager implements PluginManager {
             pluginsRoot = createPluginsRoot();
         }
 
-        System.setProperty("pf4j.pluginsDir", pluginsRoot.toString());
-
         pluginRepository = createPluginRepository();
         pluginFactory = createPluginFactory();
         extensionFactory = createExtensionFactory();


### PR DESCRIPTION
Removed unnecessary call to set pf4j.pluginsDir if plugin root is set via the constructor.