### PR TITLE
Allow a way to query all extension classes for a given plugin

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -522,6 +522,18 @@ public abstract class AbstractPluginManager implements PluginManager {
         return pluginClassLoaders.get(pluginId);
     }
 
+    @SuppressWarnings("rawtypes")
+    @Override
+    public List<Class<?>> getExtensionClasses(String pluginId) {
+        List<ExtensionWrapper> extensionsWrapper = extensionFinder.find(pluginId);
+        List<Class<?>> extensionClasses = new ArrayList<>(extensionsWrapper.size());
+        for (ExtensionWrapper extensionWrapper : extensionsWrapper) {
+            Class<?> c = extensionWrapper.getDescriptor().extensionClass;
+            extensionClasses.add(c);
+        }
+        return extensionClasses;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public <T> List<Class<T>> getExtensionClasses(Class<T> type) {
@@ -572,9 +584,9 @@ public abstract class AbstractPluginManager implements PluginManager {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List getExtensions(String pluginId) {
+    public List<Object> getExtensions(String pluginId) {
         List<ExtensionWrapper> extensionsWrapper = extensionFinder.find(pluginId);
-        List extensions = new ArrayList<>(extensionsWrapper.size());
+        List<Object> extensions = new ArrayList<>(extensionsWrapper.size());
         for (ExtensionWrapper extensionWrapper : extensionsWrapper) {
             extensions.add(extensionWrapper.getExtension());
         }

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -584,9 +584,9 @@ public abstract class AbstractPluginManager implements PluginManager {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<Object> getExtensions(String pluginId) {
+    public List getExtensions(String pluginId) {
         List<ExtensionWrapper> extensionsWrapper = extensionFinder.find(pluginId);
-        List<Object> extensions = new ArrayList<>(extensionsWrapper.size());
+        List extensions = new ArrayList<>(extensionsWrapper.size());
         for (ExtensionWrapper extensionWrapper : extensionsWrapper) {
             extensions.add(extensionWrapper.getExtension());
         }

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -131,6 +131,8 @@ public interface PluginManager {
 
     ClassLoader getPluginClassLoader(String pluginId);
 
+    List<Class<?>> getExtensionClasses(String pluginId);
+
     <T> List<Class<T>> getExtensionClasses(Class<T> type);
 
     <T> List<Class<T>> getExtensionClasses(Class<T> type, String pluginId);


### PR DESCRIPTION
What the title says. Was looking for that method in the API but I didn't see it, was there a particular reason why is it missing?

In any case, it'd work exactly the same as the other methods since the default finder is already capable of doing it.

I am partial to creating an array and returning with Arrays.asList instead of creating a new ArrayList (since as an object it's a bit more compact, or just returning an array is viable too), but that'd be a different behavior from the rest of the methods.