### PR TITLE
Update PropertiesPluginDescriptorFinder.java

### DIFF
--- a/pf4j/src/main/java/org/pf4j/PropertiesPluginDescriptorFinder.java
+++ b/pf4j/src/main/java/org/pf4j/PropertiesPluginDescriptorFinder.java
@@ -50,7 +50,7 @@ public class PropertiesPluginDescriptorFinder implements PluginDescriptorFinder 
 
     @Override
     public boolean isApplicable(Path pluginPath) {
-        return Files.exists(pluginPath) && (Files.isDirectory(pluginPath) || FileUtils.isJarFile(pluginPath));
+        return Files.exists(pluginPath) && Files.isDirectory(pluginPath)/*(Files.isDirectory(pluginPath) || FileUtils.isJarFile(pluginPath)*/);
     }
 
     @Override


### PR DESCRIPTION
Skip jar plugins
to fix   [org.pf4j.CompoundPluginDescriptorFinder.find(CompoundPluginDescriptorFinder.java:71)]  error log.