### PR TITLE
Adds ability to set plugin config directory

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -55,6 +55,12 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -620,6 +620,21 @@ public abstract class AbstractPluginManager implements PluginManager {
         return pluginsRoot;
     }
 
+    /**
+     * Add the possibility to override the plugins configuration root.
+     * If a {@code pf4j.pluginsConfigDir} system property is defined than this method returns that root.
+     * Otherwise returns the plugins root
+     *
+     * @return the plugins configuration root
+     */
+    public Path getPluginsConfigRoot() {
+        String configDir = System.getProperty("pf4j.pluginsConfigDir");
+        if (configDir == null) {
+            return pluginsRoot;
+        }
+        return Paths.get(configDir);
+    }
+
     @Override
     public RuntimeMode getRuntimeMode() {
         if (runtimeMode == null) {

--- a/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
@@ -78,7 +78,7 @@ public class DefaultPluginManager extends AbstractPluginManager {
 
     @Override
     protected PluginStatusProvider createPluginStatusProvider() {
-        return new DefaultPluginStatusProvider(getPluginsRoot());
+        return new DefaultPluginStatusProvider(getPluginsConfigRoot());
     }
 
     @Override

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
@@ -19,6 +19,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ClearSystemProperties;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.rules.TemporaryFolder;
 import org.pf4j.plugin.PluginZip;
 
@@ -34,6 +36,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DefaultPluginManagerTest {
+
+    private static final String CONFIG_DIR_PROPERTY_NAME = "pf4j.pluginsConfigDir";
 
     private DefaultPluginManager pluginManager;
     private DefaultPluginDescriptor pluginDescriptor;
@@ -155,6 +159,37 @@ public class DefaultPluginManagerTest {
 
         PluginWrapper plugin = pluginManager.getPlugin("myPlugin");
         assertSame(PluginState.DISABLED, plugin.getPluginState());
+    }
+
+    public static class TestSystemPropertiesProvided {
+
+        private static final String CONFIG_DIR_PATH = "/test/value";
+        @Rule
+        public final ProvideSystemProperty pluginConfigPropertySet = new ProvideSystemProperty(CONFIG_DIR_PROPERTY_NAME, CONFIG_DIR_PATH);
+
+        private DefaultPluginManager pluginManager = new DefaultPluginManager();
+
+        @Test
+        public void shouldReturnPluginConfigDirectoryIfProvided() {
+            Path path = pluginManager.getPluginsConfigRoot();
+
+            assertEquals(CONFIG_DIR_PATH, path.toString());
+        }
+    }
+
+    public static class TestSystemPropertiesNotProvided {
+
+        @Rule
+        public final ClearSystemProperties pluginConfigPropertyCleared = new ClearSystemProperties(CONFIG_DIR_PROPERTY_NAME);
+
+        private DefaultPluginManager pluginManager = new DefaultPluginManager();
+
+        @Test
+        public void shouldReturnPluginDirectoryIfConfigDirectoryNotProvided() {
+            Path path = pluginManager.getPluginsConfigRoot();
+
+            assertEquals("plugins", path.toString());
+        }
     }
 
 }


### PR DESCRIPTION
I have a use case where I am building a service with a number of plugins, this service is being deployed into docker. My original plan was to use the plugins directory as a volume mount, this way I can use a docker container and just mount the plugins I want to load into the container. However, I am using openshift which only allows a secret size of 1MB which is too small for some of my plugins, so instead I have had to take a different approach.

What I am doing now is building all the plugins directly into the docker image and using a volume to pick up an enabled.txt file to say which plugins should be enabled. This is fine except that the enabled.txt file needs to be in the same directory as the plugins themselves. If I want to use that directory as a volume (so that the config can be picked up dynamically) it means all the plugin jars are removed.

I am currently getting around this problem by mounting the enabled.txt file into a different folder location and then using a script to copy it into the plugins directory at startup. This works but is a bit fiddly, it would be easier if I could provide a system parameter to tell pf4j where to look for the enabled.txt file. This PR adds the ability to do this, I have just done it the quickest and easiest way I could think of, whilst also providing unit tests and it works as expected, but I am happy to refactor the changes if they don't fit with existing standards etc.