### PR TITLE
load extensions from plugin libraries

### DIFF
--- a/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java
@@ -83,14 +83,21 @@ public class LegacyExtensionFinder extends AbstractExtensionFinder {
             Set<String> bucket = new HashSet<>();
 
             try {
-                URL url = ((PluginClassLoader) plugin.getPluginClassLoader()).findResource(getExtensionsResource());
-                if (url != null) {
-                    log.debug("Read '{}'", url.getFile());
-                    try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
-                        LegacyExtensionStorage.read(reader, bucket);
-                    }
-                } else {
+                Enumeration<URL> urls = ((PluginClassLoader) plugin.getPluginClassLoader()).findResources(getExtensionsResource());
+                if (urls == null || !urls.hasMoreElements()) {
                     log.debug("Cannot find '{}'", getExtensionsResource());
+                } else {
+                    while (urls.hasMoreElements()) {
+                        URL url = urls.nextElement();
+                        if (url != null) {
+                            log.debug("Read '{}'", url.getFile());
+                            try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
+                                LegacyExtensionStorage.read(reader, bucket);
+                            }
+                        } else {
+                            log.debug("Cannot find '{}'", getExtensionsResource());
+                        }
+                    }
                 }
 
                 debugExtensions(bucket);

--- a/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java
@@ -89,13 +89,9 @@ public class LegacyExtensionFinder extends AbstractExtensionFinder {
                 } else {
                     while (urls.hasMoreElements()) {
                         URL url = urls.nextElement();
-                        if (url != null) {
-                            log.debug("Read '{}'", url.getFile());
-                            try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
-                                LegacyExtensionStorage.read(reader, bucket);
-                            }
-                        } else {
-                            log.debug("Cannot find '{}'", getExtensionsResource());
+                        log.debug("Read '{}'", url.getFile());
+                        try (Reader reader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) {
+                            LegacyExtensionStorage.read(reader, bucket);
                         }
                     }
                 }

--- a/pf4j/src/main/java/org/pf4j/ServiceProviderExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/ServiceProviderExtensionFinder.java
@@ -101,18 +101,14 @@ public class ServiceProviderExtensionFinder extends AbstractExtensionFinder {
                 } else {
                     while (urls.hasMoreElements()) {
                         URL url = urls.nextElement();
-                        if (url != null) {
-                            Path extensionPath;
-                            if (url.toURI().getScheme().equals("jar")) {
-                                extensionPath = FileUtils.getPath(url.toURI(), getExtensionsResource());
-                            } else {
-                                extensionPath = Paths.get(url.toURI());
-                            }
-
-                            bucket.addAll(readExtensions(extensionPath));
+                        Path extensionPath;
+                        if (url.toURI().getScheme().equals("jar")) {
+                            extensionPath = FileUtils.getPath(url.toURI(), getExtensionsResource());
                         } else {
-                            log.debug("Cannot find '{}'", getExtensionsResource());
+                            extensionPath = Paths.get(url.toURI());
                         }
+
+                        bucket.addAll(readExtensions(extensionPath));
                     }
                 }
 


### PR DESCRIPTION
The extension finder does not take plugin libraries (in the plugin's `lib` directory) into consideration. 

This pull request updates the `LegacyExtensionFinder` / `ServiceProviderExtensionFinder` class in order to scan the plugin libraries for `META-INF/extensions.idx` / `META-INF/services`.