### PR TITLE
explicitly configure extension points for an extension

### DIFF
--- a/pf4j/src/main/java/org/pf4j/Extension.java
+++ b/pf4j/src/main/java/org/pf4j/Extension.java
@@ -34,4 +34,13 @@ public @interface Extension {
 
     int ordinal() default 0;
 
+    /**
+     * An array of extension points, that are implemented by this extension.
+     * This explicit configuration overrides the automatic detection of extension points in the
+     * {@link org.pf4j.processor.ExtensionAnnotationProcessor}.
+     *
+     * @return classes of extension points implemented by this extension
+     */
+    Class<? extends ExtensionPoint>[] provides() default {};
+
 }

--- a/pf4j/src/main/java/org/pf4j/Extension.java
+++ b/pf4j/src/main/java/org/pf4j/Extension.java
@@ -38,8 +38,12 @@ public @interface Extension {
      * An array of extension points, that are implemented by this extension.
      * This explicit configuration overrides the automatic detection of extension points in the
      * {@link org.pf4j.processor.ExtensionAnnotationProcessor}.
+     * <p>
+     * In case your extension is directly derived from an extension point this attribute is NOT required.
+     * But under certain <a href="https://github.com/pf4j/pf4j/issues/264">more complex scenarios</a> it
+     * might be useful to explicitly set the extension points for an extension.
      *
-     * @return classes of extension points implemented by this extension
+     * @return classes of extension points, that are implemented by this extension
      */
     Class<? extends ExtensionPoint>[] points() default {};
 

--- a/pf4j/src/main/java/org/pf4j/Extension.java
+++ b/pf4j/src/main/java/org/pf4j/Extension.java
@@ -41,6 +41,6 @@ public @interface Extension {
      *
      * @return classes of extension points implemented by this extension
      */
-    Class<? extends ExtensionPoint>[] provides() default {};
+    Class<? extends ExtensionPoint>[] points() default {};
 
 }

--- a/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java
+++ b/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java
@@ -17,6 +17,7 @@ package org.pf4j.processor;
 
 import org.pf4j.Extension;
 import org.pf4j.ExtensionPoint;
+import org.pf4j.util.ClassUtils;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -25,7 +26,6 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
@@ -104,9 +104,9 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             List<TypeElement> extensionPointElements;
 
             // use extension points, that were explicitly set in the extension annotation
-            AnnotationMirror annotation = getAnnotationMirror(extensionElement, Extension.class);
+            AnnotationMirror annotation = ClassUtils.getAnnotationMirror(extensionElement, Extension.class);
             AnnotationValue annotatedExtensionPoints = (annotation != null) ?
-                getAnnotationValue(annotation, "provides") :
+                ClassUtils.getAnnotationValue(annotation, "provides") :
                 null;
             List<? extends AnnotationValue> extensionPointClasses = (annotatedExtensionPoints != null) ?
                 (List<? extends AnnotationValue>) annotatedExtensionPoints.getValue() :
@@ -252,28 +252,5 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         }
 
         return storage;
-    }
-
-    private static AnnotationMirror getAnnotationMirror(TypeElement typeElement, Class<?> clazz) {
-        // get annotation of a type element
-        // as described at https://stackoverflow.com/a/10167558
-        String clazzName = clazz.getName();
-        for (AnnotationMirror m : typeElement.getAnnotationMirrors()) {
-            if (m.getAnnotationType().toString().equals(clazzName)) {
-                return m;
-            }
-        }
-        return null;
-    }
-
-    private static AnnotationValue getAnnotationValue(AnnotationMirror annotationMirror, String key) {
-        // get annotation value of a type element
-        // as described at https://stackoverflow.com/a/10167558
-        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror.getElementValues().entrySet()) {
-            if (entry.getKey().getSimpleName().toString().equals(key)) {
-                return entry.getValue();
-            }
-        }
-        return null;
     }
 }

--- a/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java
+++ b/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java
@@ -171,7 +171,7 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
         List<TypeElement> extensionPointElements = new ArrayList<>();
 
         // use extension points, that were explicitly set in the extension annotation
-        AnnotationValue annotatedExtensionPoints = ClassUtils.getAnnotationValue(extensionElement, Extension.class, "provides");
+        AnnotationValue annotatedExtensionPoints = ClassUtils.getAnnotationValue(extensionElement, Extension.class, "points");
         List<? extends AnnotationValue> extensionPointClasses = (annotatedExtensionPoints != null) ?
             (List<? extends AnnotationValue>) annotatedExtensionPoints.getValue() :
             null;

--- a/pf4j/src/main/java/org/pf4j/util/ClassUtils.java
+++ b/pf4j/src/main/java/org/pf4j/util/ClassUtils.java
@@ -15,9 +15,14 @@
  */
 package org.pf4j.util;
 
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Decebal Suiu
@@ -71,6 +76,43 @@ public class ClassUtils {
         return list;
     }
     */
+
+    /**
+     * Get a certain annotation of a {@link TypeElement}.
+     * See <a href="https://stackoverflow.com/a/10167558">stackoverflow.com</a> for more information.
+     *
+     * @param typeElement the type element, that contains the requested annotation
+     * @param clazz the class of the requested annotation
+     * @return the requested annotation or null, if no annotation of the provided class was found on the type element
+     * @throws NullPointerException if one of the parameters is null
+     */
+    public static AnnotationMirror getAnnotationMirror(TypeElement typeElement, Class<?> clazz) {
+        String clazzName = clazz.getName();
+        for (AnnotationMirror m : typeElement.getAnnotationMirrors()) {
+            if (m.getAnnotationType().toString().equals(clazzName)) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get a certain parameter of an {@link AnnotationMirror}.
+     * See <a href="https://stackoverflow.com/a/10167558">stackoverflow.com</a> for more information.
+     *
+     * @param annotationMirror the annotation, that contains the requested parameter
+     * @param key the name of the requested parameter
+     * @return the requested parameter or null, if no parameter of the provided name was found on the annotation
+     * @throws NullPointerException if the annotationMirror parameter is null
+     */
+    public static AnnotationValue getAnnotationValue(AnnotationMirror annotationMirror, String key) {
+        for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror.getElementValues().entrySet()) {
+            if (entry.getKey().getSimpleName().toString().equals(key)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
 
     /**
      * Uses {@link Class#getSimpleName()} to convert from {@link Class} to {@link String}.

--- a/pf4j/src/main/java/org/pf4j/util/ClassUtils.java
+++ b/pf4j/src/main/java/org/pf4j/util/ClassUtils.java
@@ -82,14 +82,14 @@ public class ClassUtils {
      * See <a href="https://stackoverflow.com/a/10167558">stackoverflow.com</a> for more information.
      *
      * @param typeElement the type element, that contains the requested annotation
-     * @param clazz the class of the requested annotation
-     * @return the requested annotation or null, if no annotation of the provided class was found on the type element
-     * @throws NullPointerException if one of the parameters is null
+     * @param annotationClass the class of the requested annotation
+     * @return the requested annotation or null, if no annotation of the provided class was found
+     * @throws NullPointerException if <code>typeElement</code> or <code>annotationClass</code> is null
      */
-    public static AnnotationMirror getAnnotationMirror(TypeElement typeElement, Class<?> clazz) {
-        String clazzName = clazz.getName();
+    public static AnnotationMirror getAnnotationMirror(TypeElement typeElement, Class<?> annotationClass) {
+        String annotationClassName = annotationClass.getName();
         for (AnnotationMirror m : typeElement.getAnnotationMirrors()) {
-            if (m.getAnnotationType().toString().equals(clazzName)) {
+            if (m.getAnnotationType().toString().equals(annotationClassName)) {
                 return m;
             }
         }
@@ -101,17 +101,34 @@ public class ClassUtils {
      * See <a href="https://stackoverflow.com/a/10167558">stackoverflow.com</a> for more information.
      *
      * @param annotationMirror the annotation, that contains the requested parameter
-     * @param key the name of the requested parameter
-     * @return the requested parameter or null, if no parameter of the provided name was found on the annotation
-     * @throws NullPointerException if the annotationMirror parameter is null
+     * @param annotationParameter the name of the requested annotation parameter
+     * @return the requested parameter or null, if no parameter of the provided name was found
+     * @throws NullPointerException if <code>annotationMirror</code> is null
      */
-    public static AnnotationValue getAnnotationValue(AnnotationMirror annotationMirror, String key) {
+    public static AnnotationValue getAnnotationValue(AnnotationMirror annotationMirror, String annotationParameter) {
         for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : annotationMirror.getElementValues().entrySet()) {
-            if (entry.getKey().getSimpleName().toString().equals(key)) {
+            if (entry.getKey().getSimpleName().toString().equals(annotationParameter)) {
                 return entry.getValue();
             }
         }
         return null;
+    }
+
+    /**
+     * Get a certain annotation parameter of a {@link TypeElement}.
+     * See <a href="https://stackoverflow.com/a/10167558">stackoverflow.com</a> for more information.
+     *
+     * @param typeElement the type element, that contains the requested annotation
+     * @param annotationClass the class of the requested annotation
+     * @param annotationParameter the name of the requested annotation parameter
+     * @return the requested parameter or null, if no annotation for the provided class was found or no annotation parameter was found
+     * @throws NullPointerException if <code>typeElement</code> or <code>annotationClass</code> is null
+     */
+    public static AnnotationValue getAnnotationValue(TypeElement typeElement, Class<?> annotationClass, String annotationParameter) {
+        AnnotationMirror annotationMirror = getAnnotationMirror(typeElement, annotationClass);
+        return (annotationMirror != null) ?
+            getAnnotationValue(annotationMirror, annotationParameter) :
+            null;
     }
 
     /**


### PR DESCRIPTION
This pull requests provides a possible workaround for issue #264.

An extension may provide its implemented extension points explicitly through its annotation. According to my example in issue #264 you might use:

```java
@Extension(provides = {BootExtensionPoint.class})
public class Plugin1BootExtension extends BootAdapter {
    // ... some implementations 
}
```

If the `@Extension` provides its implemented extension points through the `provides` attribute, there is no need for the annotation processor to detect the extension points automatically, which currently fails under the described conditions.

I know, that this might not the best approach. I guess you also can improve the automatic detection of extension points in the [`findExtensionPoints`](https://github.com/pf4j/pf4j/blob/ab12f7fa5a95dd570f2e62812a243d48411c1dce/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java#L168-L191) method. But with this pull request I don't want to break compatibility by changing your current implementation. Therefore I've decided not to change your implementation and keep it as a default behaviour.

In general I'm not sure, if an improved [`findExtensionPoints`](https://github.com/pf4j/pf4j/blob/ab12f7fa5a95dd570f2e62812a243d48411c1dce/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java#L168-L191) method would work in every possible use case as expected. Therefore it might be quite helpful to have a solution, that circumvents the automatic detection.

Please let me know, what you think about this solution.