### PR TITLE
ServiceProviderExtensionFinder should scan the whole classpath

### DIFF
--- a/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java
@@ -53,7 +53,11 @@ public class LegacyExtensionFinder extends AbstractExtensionFinder {
         Set<String> bucket = new HashSet<>();
         try {
             Enumeration<URL> urls = getClass().getClassLoader().getResources(getExtensionsResource());
-            collectExtensions(urls, bucket);
+            if (urls.hasMoreElements()) {
+                collectExtensions(urls, bucket);
+            } else {
+                log.debug("Cannot find '{}'", getExtensionsResource());
+            }
 
             debugExtensions(bucket);
 

--- a/pf4j/src/main/java/org/pf4j/ServiceProviderExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/ServiceProviderExtensionFinder.java
@@ -61,9 +61,11 @@ public class ServiceProviderExtensionFinder extends AbstractExtensionFinder {
 
         final Set<String> bucket = new HashSet<>();
         try {
-            URL url = getClass().getClassLoader().getResource(getExtensionsResource());
-            if (url != null) {
-                collectExtensions(url, bucket);
+            Enumeration<URL> urls = getClass().getClassLoader().getResources(getExtensionsResource());
+            if (urls.hasMoreElements()) {
+                collectExtensions(urls, bucket);
+            } else {
+                log.debug("Cannot find '{}'", getExtensionsResource());
             }
 
             debugExtensions(bucket);
@@ -90,10 +92,7 @@ public class ServiceProviderExtensionFinder extends AbstractExtensionFinder {
             try {
                 Enumeration<URL> urls = ((PluginClassLoader) plugin.getPluginClassLoader()).findResources(getExtensionsResource());
                 if (urls.hasMoreElements()) {
-                    while (urls.hasMoreElements()) {
-                        URL url = urls.nextElement();
-                        collectExtensions(url, bucket);
-                    }
+                    collectExtensions(urls, bucket);
                 } else {
                     log.debug("Cannot find '{}'", getExtensionsResource());
                 }
@@ -107,6 +106,14 @@ public class ServiceProviderExtensionFinder extends AbstractExtensionFinder {
         }
 
         return result;
+    }
+
+    private void collectExtensions(Enumeration<URL> urls, Set<String> bucket) throws URISyntaxException, IOException {
+        while (urls.hasMoreElements()) {
+            URL url = urls.nextElement();
+            log.debug("Read '{}'", url.getFile());
+            collectExtensions(url, bucket);
+        }
     }
 
     private void collectExtensions(URL url, Set<String> bucket) throws URISyntaxException, IOException {


### PR DESCRIPTION
This pull request fixes issue #272.

Similar to the implementation in [`LegacyExtensionFinder#readClasspathStorages()`](https://github.com/pf4j/pf4j/blob/39219b3ba4a8bc7c13e6ede8d7157518e266bba1/pf4j/src/main/java/org/pf4j/LegacyExtensionFinder.java#L49-L66) the `ServiceProviderExtensionFinder` should also iterate over all available `META-INF/services` directories (see [this commit](https://github.com/pf4j/pf4j/pull/273/commits/0f715f09e871d1920b891f53cded2c9562198d9c)).

Besides this I made a little change to `LegacyExtensionFinder#readClasspathStorages()` in order to have a more consistent logging (see [this commit](https://github.com/pf4j/pf4j/pull/273/commits/d1500cd4c466cd9e16ae8710c6e6f82012edaffb)).