### PR TITLE
add automatic module name to pf4j.jar

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -23,6 +23,17 @@
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.pf4j</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
According to [this recommendation](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) the `pf4j.jar` file should provide an `Automatic-Module-Name` in its `MANIFEST.MF`. This pull requests extends the `pom.xml` in order to add the line 

```
Automatic-Module-Name: org.pf4j
```

to the `MANIFEST.MF` of `pf4j.jar` (see [this commit](https://github.com/pf4j/pf4j/pull/275/commits/992aa3012de64e6b002a07ead034b76ef90cc878)). In case PF4J is migrated to Jigsaw (Java 9+) in the future, you can use `org.pf4j` in the `module-info.java` without getting conflicts with application, that already make use of Jigsaw (Java 9+).

I didn't make any changes to the demo application. Because in most cases the demo libraries aren't reused by other applications.