### PR TITLE
Fix the plugins in the demo did not load successfully

### DIFF
--- a/demo/plugins/pom.xml
+++ b/demo/plugins/pom.xml
@@ -102,9 +102,7 @@
             <artifactId>pf4j-demo-api</artifactId>
             <version>${project.version}</version>
             <!-- !!! VERY IMPORTANT -->
-            <!--
             <scope>provided</scope>
-            -->
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I tried running `run-demo.sh` and found that the results were not correct: WelcomePlugin and HelloPlugin could be loaded, but the extensions didn't work. 

The log message:

```
Found 1 extensions for extension point 'org.pf4j.demo.api.Greeting'
>>> Whazzup

WelcomePlugin.start()
HelloPlugin.start()

HelloPlugin.stop()
WelcomePlugin.stop()
```

I found it was due to a modification of a commit: https://github.com/pf4j/pf4j/commit/254c9cc9ebb6743c5fa526044a67e2aaa0101b7c

The log after the repair is:
```
Found 3 extensions for extension point 'org.pf4j.demo.api.Greeting'
>>> Whazzup
>>> Welcome
>>> Hello

WelcomePlugin.start()
HelloPlugin.start()

HelloPlugin.stop()
WelcomePlugin.stop()
```

Thanks.