### PR TITLE
Make the project build on Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ jdk:
 # JDK7 is not supported anymore; https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
 #    - oraclejdk7
     - oraclejdk8
+    - openjdk11
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/demo/app/pom.xml
+++ b/demo/app/pom.xml
@@ -42,7 +42,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/demo/plugins/pom.xml
+++ b/demo/plugins/pom.xml
@@ -31,7 +31,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <asm.version>7.0</asm.version>
 
         <junit.version>4.12</junit.version>
-        <mockito.version>2.0.28-beta</mockito.version>
+        <mockito.version>2.24.0</mockito.version>
         <cobertura.version>2.7</cobertura.version>
         <coveralls.version>3.1.0</coveralls.version>
 
@@ -62,20 +62,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <optimize>true</optimize>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.0.1</version>
                 <configuration>
                     <skip>${javadoc.disabled}</skip>
+                    <doclint>none</doclint>
+                    <failOnWarnings>false</failOnWarnings>
                 </configuration>
                 <executions>
                     <execution>
@@ -89,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.0.1</version>
                 <configuration>
                     <skipSource>${source.disabled}</skipSource>
                 </configuration>
@@ -125,12 +126,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.1.0</version>
             </plugin>
 
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.6</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -150,12 +151,15 @@
 
     <profiles>
         <profile>
-            <id>jdk8-build</id>
+            <!-- Disable Javadoc generation on Java 11, as it fails with message on 11.0.2:
+                 "error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/7/docs/api/ are in the unnamed module."
+                 -->
+            <id>jdk11-build</id>
             <activation>
-                <jdk>[1.8,)</jdk>
+                <jdk>[11, 12)</jdk>
             </activation>
             <properties>
-                <additionalparam>-Xdoclint:none</additionalparam>
+                <javadoc.disabled>true</javadoc.disabled>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -58,18 +58,31 @@
     </properties>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <showWarnings>true</showWarnings>
-                </configuration>
-            </plugin>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <showWarnings>true</showWarnings>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                    </configuration>
+                </plugin>
 
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -132,7 +145,6 @@
 
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Update dependencies to enable build on Java 11:
- Update Mockito and plugins for 11 support.
- Disable doclint as there are numerous Javadoc issues reported.
- Remove jdk8-build profile, as 'additionalparam' property isn't
  used in POM.
- Disable Javadoc generation on 11+, as it currently fails.

Add travis build on OpenJDK11.