### PR TITLE
Document where the pluginId comes from

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -338,7 +338,7 @@ public abstract class AbstractPluginManager implements PluginManager {
     }
 
     /**
-     * Start the specified plugin and it's dependencies.
+     * Start the specified plugin and its dependencies.
      */
     @Override
     public PluginState startPlugin(String pluginId) {

--- a/pf4j/src/main/java/org/pf4j/DependencyResolver.java
+++ b/pf4j/src/main/java/org/pf4j/DependencyResolver.java
@@ -106,7 +106,7 @@ public class DependencyResolver {
     /**
      * Retrieves the plugins ids that the given plugin id directly depends on.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return
      */
     public List<String> getDependencies(String pluginId) {
@@ -117,7 +117,7 @@ public class DependencyResolver {
     /**
      * Retrieves the plugins ids that the given content is a direct dependency of.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return
      */
     public List<String> getDependents(String pluginId) {

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -55,7 +55,7 @@ public interface PluginManager {
     /**
      * Retrieves the plugin with this id, or null if the plugin does not exist.
      *
-     * @param pluginId The pluginId for the plugin you are trying to get.
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return A PluginWrapper object for this plugin, or null if it does not exist.
      */
     PluginWrapper getPlugin(String pluginId);
@@ -68,8 +68,9 @@ public interface PluginManager {
     /**
      * Load a plugin.
      *
-     * @param pluginPath
-     * @return the pluginId of the installed plugin or null
+     * @param pluginPath the plugin location
+     * @return the pluginId of the installed plugin as specified in
+     *     its {@linkplain PluginDescriptor metadata}; or {@code null}
      */
     String loadPlugin(Path pluginPath);
 
@@ -100,7 +101,7 @@ public interface PluginManager {
     /**
      * Unload a plugin.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return true if the plugin was unloaded
      */
     boolean unloadPlugin(String pluginId);
@@ -108,7 +109,7 @@ public interface PluginManager {
     /**
      * Disables a plugin from being loaded.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return true if plugin is disabled
      */
     boolean disablePlugin(String pluginId);
@@ -116,7 +117,7 @@ public interface PluginManager {
     /**
      * Enables a plugin that has previously been disabled.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return true if plugin is enabled
      */
     boolean enablePlugin(String pluginId);
@@ -124,7 +125,7 @@ public interface PluginManager {
     /**
      * Deletes a plugin.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return true if the plugin was deleted
      */
     boolean deletePlugin(String pluginId);

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -79,7 +79,7 @@ public interface PluginManager {
     void startPlugins();
 
     /**
-     * Start the specified plugin and it's dependencies.
+     * Start the specified plugin and its dependencies.
      *
      * @return the plugin state
      */
@@ -91,7 +91,7 @@ public interface PluginManager {
     void stopPlugins();
 
     /**
-     * Stop the specified plugin and it's dependencies.
+     * Stop the specified plugin and its dependencies.
      *
      * @return the plugin state
      */

--- a/pf4j/src/main/java/org/pf4j/PluginStatusProvider.java
+++ b/pf4j/src/main/java/org/pf4j/PluginStatusProvider.java
@@ -24,7 +24,7 @@ public interface PluginStatusProvider {
     /**
      * Checks if the plugin is disabled or not
      *
-     * @param pluginId the plugin id
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return if the plugin is disabled or not
      */
     boolean isPluginDisabled(String pluginId);
@@ -32,7 +32,7 @@ public interface PluginStatusProvider {
     /**
      * Disables a plugin from being loaded.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return true if plugin is disabled
      */
     boolean disablePlugin(String pluginId);
@@ -40,7 +40,7 @@ public interface PluginStatusProvider {
     /**
      * Enables a plugin that has previously been disabled.
      *
-     * @param pluginId
+     * @param pluginId the unique plugin identifier, specified in its metadata
      * @return true if plugin is enabled
      */
     boolean enablePlugin(String pluginId);


### PR DESCRIPTION
Document that `pluginId` comes from the plugin metadata. The metadata
currently can be specified in either JAR manifest as "Plugin-Id" or in a property file as "plugin.id".