### PR TITLE
Check no plugin with same pluginId is loaded

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -60,6 +60,26 @@
             <version>${asm.version}</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <!-- An empty artifact, required while JUnit 4 is on the classpath to override its
+                 dependency on hamcrest.
+
+                 See http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
+                 -->
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -836,12 +836,12 @@ public abstract class AbstractPluginManager implements PluginManager {
         pluginId = pluginDescriptor.getPluginId();
         if (plugins.containsKey(pluginId)) {
             PluginWrapper loadedPlugin = getPlugin(pluginId);
-            throw new PluginException(String.format("There is an already loaded plugin (%s) "
-                    + "with the same id (%s) as the plugin at path '%s'. Simultaneous loading "
+            throw new PluginException("There is an already loaded plugin ({}) "
+                    + "with the same id ({}) as the plugin at path '{}'. Simultaneous loading "
                     + "of plugins with the same PluginId is not currently supported.\n"
                     + "As a workaround you may include PluginVersion and PluginProvider "
                     + "in PluginId.",
-                loadedPlugin, pluginId, pluginPath));
+                loadedPlugin, pluginId, pluginPath);
         }
 
         log.debug("Found descriptor {}", pluginDescriptor);

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -49,17 +49,17 @@ public abstract class AbstractPluginManager implements PluginManager {
 
     private PluginDescriptorFinder pluginDescriptorFinder;
 
-    /*
+    /**
      * A map of plugins this manager is responsible for (the key is the 'pluginId').
      */
     protected Map<String, PluginWrapper> plugins;
 
-    /*
+    /**
      * A map of plugin class loaders (the key is the 'pluginId').
      */
     private Map<String, ClassLoader> pluginClassLoaders;
 
-    /*
+    /**
      * A list with unresolved plugins (unresolved dependency).
      */
     private List<PluginWrapper> unresolvedPlugins;
@@ -69,23 +69,23 @@ public abstract class AbstractPluginManager implements PluginManager {
      */
     private List<PluginWrapper> resolvedPlugins;
 
-    /*
+    /**
      * A list with started plugins.
      */
     private List<PluginWrapper> startedPlugins;
 
-    /*
+    /**
      * The registered {@link PluginStateListener}s.
      */
     private List<PluginStateListener> pluginStateListeners;
 
-    /*
+    /**
      * Cache value for the runtime mode.
      * No need to re-read it because it wont change at runtime.
      */
     private RuntimeMode runtimeMode;
 
-    /*
+    /**
      * The system version used for comparisons to the plugin requires attribute.
      */
     private String systemVersion = "0.0.0";

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -15,10 +15,6 @@
  */
 package org.pf4j;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.pf4j.util.StringUtils;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,6 +27,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.pf4j.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class implements the boilerplate plugin code that any {@link PluginManager}
@@ -820,18 +819,31 @@ public abstract class AbstractPluginManager implements PluginManager {
     }
 
     protected PluginWrapper loadPluginFromPath(Path pluginPath) throws PluginException {
-        // test for plugin duplication
+        // Test for plugin path duplication
         String pluginId = idForPath(pluginPath);
         if (pluginId != null) {
             throw new PluginAlreadyLoadedException(pluginId, pluginPath);
         }
 
-        // retrieves the plugin descriptor
+        // Retrieve and validate the plugin descriptor
         PluginDescriptorFinder pluginDescriptorFinder = getPluginDescriptorFinder();
         log.debug("Use '{}' to find plugins descriptors", pluginDescriptorFinder);
         log.debug("Finding plugin descriptor for plugin '{}'", pluginPath);
         PluginDescriptor pluginDescriptor = pluginDescriptorFinder.find(pluginPath);
         validatePluginDescriptor(pluginDescriptor);
+
+        // Check there are no loaded plugins with the retrieved id
+        pluginId = pluginDescriptor.getPluginId();
+        if (plugins.containsKey(pluginId)) {
+            PluginWrapper loadedPlugin = getPlugin(pluginId);
+            throw new PluginException(String.format("There is an already loaded plugin (%s) "
+                    + "with the same id (%s) as the plugin at path '%s'. Simultaneous loading "
+                    + "of plugins with the same PluginId is not currently supported.\n"
+                    + "As a workaround you may include PluginVersion and PluginProvider "
+                    + "in PluginId.",
+                loadedPlugin, pluginId, pluginPath));
+        }
+
         log.debug("Found descriptor {}", pluginDescriptor);
         String pluginClassName = pluginDescriptor.getPluginClass();
         log.debug("Class '{}' for plugin '{}'",  pluginClassName, pluginPath);

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <asm.version>7.0</asm.version>
 
         <junit.version>4.12</junit.version>
+        <hamcrest.version>2.1</hamcrest.version>
         <mockito.version>2.24.0</mockito.version>
         <cobertura.version>2.7</cobertura.version>
         <coveralls.version>3.1.0</coveralls.version>


### PR DESCRIPTION
Check no plugin with same pluginId is loaded before loading a new plugin.

Also, update Hamcrest to [2.1](https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1).

Fixes #286