### PR TITLE
Provide a module descriptor for Java 9+

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -23,7 +23,6 @@
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
                 <executions>
-
                     <!-- compile everything for Java 8 except the module-info.java -->
                     <execution>
                         <id>default-compile</id>
@@ -51,7 +50,6 @@
                             </includes>
                         </configuration>
                     </execution>
-
                 </executions>
             </plugin>
         </plugins>
@@ -89,11 +87,12 @@
         </dependency>
 
         <dependency>
-            <!-- An empty artifact, required while JUnit 4 is on the classpath to override its
-                 dependency on hamcrest.
+            <!-- 
+            An empty artifact, required while JUnit 4 is on the classpath to override its
+            dependency on hamcrest.
 
-                 See http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
-                 -->
+            See http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
+            -->
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>${hamcrest.version}</version>

--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -22,17 +22,37 @@
                 <configuration>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.pf4j</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
+                <executions>
+
+                    <!-- compile everything for Java 8 except the module-info.java -->
+                    <execution>
+                        <id>default-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+
+                    <!-- compile module-info.java for Java 9+ -->
+                    <execution>
+                        <id>java9-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                            <includes>
+                                <include>module-info.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pf4j/src/main/java/module-info.java
+++ b/pf4j/src/main/java/module-info.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Module descriptor for PF4J.
+ *
+ * @author Decebal Suiu
+ * @author Andreas Rudolph
+ */
+module org.pf4j {
+    requires java.base;
+
+    // provides javax.annotation
+    requires java.compiler;
+
+    // provided by the ASM library
+    requires org.objectweb.asm;
+
+    // The SLF4J library currently does not provide a module.
+    // Version 1.8 provides a module called "org.slf4j". But this version is
+    // currently in beta stage. Therefore I'm not sure, if we already like to
+    // use it.
+    requires slf4j.api;
+
+    // The java-semver library currently does not provide a module.
+    // Maybe we should send them a pull request, that at least they provide an
+    // automatic module name in their MANIFEST file.
+    requires java.semver;
+
+    // Maybe we should reconsider the package hierarchy, that only classes are
+    // exported, which are required by 3rd party developers.
+    exports org.pf4j;
+    exports org.pf4j.processor;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
 
         <slf4j.version>1.7.25</slf4j.version>
         <asm.version>7.1</asm.version>


### PR DESCRIPTION
This pull request addresses issue #299.

A `module-info.java` file was created. It defines the following requirements:

- [`java.base`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/module-summary.html) is always required. We don't really need to define this, but I like to set this for the sake of completeness.
- [`java.compiler`](https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/module-summary.html) is required for annotation processing.
- `org.objectweb.asm` is provided by the ASM library.
- `slf4j.api` is automatically named, because the library does not provide its own module name. Version 1.8 defines a module called `org.slf4j`. But this version is currently in beta stage. Therefore I'm not sure, if we already like to use it.
- `java.semver` is automatically named, because the library does not provide its own module name. Maybe we should send them a pull request, that at least they provide an automatic module name in their MANIFEST file. Alternatively we might integrate their source code directly into PF4J.

Currently the module exports the following packages:

- `org.pf4j`
- `org.pf4j.processor`

I'm not sure, if other exports are also necessary. Maybe we should reconsider the package hierarchy in general, that only classes are exported, which are required by 3rd party developers.

The created `pf4j.jar` file contains a subfolder `META-INF/versions/9` with the compiled `module-info.class` for Java 9+. This differs from my initial proposal #299, where I suggested to put this file into the root folder of the JAR file. But I guess this approach is a bit more reliable, because a Java 8 environment won't read this file accidentally. SLF4J in version 1.8-beta follows the same approach.

Currently I have only one little problem. According to the `.gitignore` file I guess you're also using IntelliJ IDEA? - I had to **disable automatic import of Maven projects** in the project settings and had to set **Language Level 9** for the `pf4j` module. Otherwise the IDE shows an error, if `module-info.java` is edited. Jetbrains currently offers a quite [ugly workaround](https://blog.jetbrains.com/idea/2017/10/creating-multi-release-jar-files-in-intellij-idea/), that I didn't wanted to implement due to its unnecessary complexity.