### PR TITLE
set version number to 3.0.0-SNAPSHOT

### DIFF
--- a/demo/api/pom.xml
+++ b/demo/api/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.pf4j.demo</groupId>
         <artifactId>pf4j-demo-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pf4j-demo-api</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Demo Api</name>
 

--- a/demo/app/pom.xml
+++ b/demo/app/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.pf4j.demo</groupId>
         <artifactId>pf4j-demo-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pf4j-demo-app</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Demo App</name>
 

--- a/demo/plugins/plugin1/pom.xml
+++ b/demo/plugins/plugin1/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.pf4j.demo</groupId>
         <artifactId>pf4j-demo-plugins</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pf4j-demo-plugin1</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Demo Plugin #1</name>
 

--- a/demo/plugins/plugin2/pom.xml
+++ b/demo/plugins/plugin2/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.pf4j.demo</groupId>
         <artifactId>pf4j-demo-plugins</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pf4j-demo-plugin2</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Demo Plugin #2</name>
 

--- a/demo/plugins/pom.xml
+++ b/demo/plugins/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.pf4j.demo</groupId>
         <artifactId>pf4j-demo-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pf4j-demo-plugins</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Demo Plugins Parent</name>
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <groupId>org.pf4j</groupId>
         <artifactId>pf4j-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.pf4j.demo</groupId>
     <artifactId>pf4j-demo-parent</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Demo Parent</name>
 

--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.pf4j</groupId>
         <artifactId>pf4j-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pf4j</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>PF4J</name>
     <description>Plugin Framework for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.pf4j</groupId>
     <artifactId>pf4j-parent</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>PF4J Parent</name>
     <description>Plugin Framework for Java</description>


### PR DESCRIPTION
For a better distinction between the different development branches, I would suggest to update the version numbers in the `pf4j_3` branch to `3.0.0-SNAPSHOT`.