### PR TITLE
compile demo plugins for Java 8

### DIFF
--- a/demo/plugins/pom.xml
+++ b/demo/plugins/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
 
         <!-- Override below properties in each plugin's pom.xml -->
         <plugin.id />

--- a/demo/plugins/pom.xml
+++ b/demo/plugins/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
 
         <!-- Override below properties in each plugin's pom.xml -->
         <plugin.id />
@@ -28,14 +27,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Because Java 8 is required with PF4J 3, it doesn't really make sense to compile the demo plugins for Java 7. Therefore I've updated the `pom.xml` accordingly.

In general I'm not sure, if we really need this setting anyway. Do you have any reason for providing the target Java version here again? - If we would remove this setting, it would be automatically inherited from the the root `pom.xml`, where `<maven.compiler.release>8</maven.compiler.release>` is already configured.