### PR TITLE
add "Multi-Release" to manifest

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -52,6 +52,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
During some tests with PF4J 3 I've discovered a problem related to Java modules. I've converted the demo application to Java 11 modules. It uses a similar structure, a developer would use for a new project based on PF4J & Java 11.

Compiling this project with Java 11 leads to an error message. The compiler does not find the `module-info.class` introduced with #300. In the current state the module is not usable, because it is placed in the `META-INF/versions/9` folder of the JAR file. In this case we need to add the line `Multi-Release: true` to the manifest of pf4j.jar as described [here](https://maven.apache.org/plugins/maven-compiler-plugin/multirelease.html#The_.22forward_compatibility.22_solution) and [here](https://dzone.com/articles/creating-multi-release-jar-files-in-intellij-idea).

This pull request adds the missing line to the manifest. Afterwards I can use PF4J as a module in my Java 11 based test application.