### PR TITLE
Fix FileSystemException in windows on plugin delete

### DIFF
--- a/pf4j/src/main/java/org/pf4j/processor/LegacyExtensionStorage.java
+++ b/pf4j/src/main/java/org/pf4j/processor/LegacyExtensionStorage.java
@@ -45,18 +45,16 @@ public class LegacyExtensionStorage extends ExtensionStorage {
     }
 
     public static void read(Reader reader, Set<String> entries) throws IOException {
-        BufferedReader bufferedReader = new BufferedReader(reader);
-
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            line = COMMENT.matcher(line).replaceFirst("");
-            line = WHITESPACE.matcher(line).replaceAll("");
-            if (line.length() > 0) {
-                entries.add(line);
+        try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                line = COMMENT.matcher(line).replaceFirst("");
+                line = WHITESPACE.matcher(line).replaceAll("");
+                if (line.length() > 0) {
+                    entries.add(line);
+                }
             }
         }
-
-        bufferedReader.close();
     }
 
     @Override


### PR DESCRIPTION
Fixes "java.nio.file.FileSystemException: The process cannot access the
file because it is being used by another process." when deleting an
unloaded plugin.

In windows, deleting the plugin jar file fails because it stays open
despite calling UrlClassLoader.close(). Fixed by using
java.net.URLClassLoader.getResourceAsStream(String) instead of
java.net.URLClassLoader.findResources(String) to load extensions.idx.
The java.net.URLClassLoader.getResourceAsStream(String) collects the
input streams returned (for files and jar files) internally and closes
them when java.net.URLClassLoader.close() is called.

TODO: Add Unit-Test case for org.pf4j.LegacyExtensionFinder.readPluginsStorages()