### PR TITLE
Make PluginWrapper methods public

### DIFF
--- a/pf4j/src/main/java/org/pf4j/PluginWrapper.java
+++ b/pf4j/src/main/java/org/pf4j/PluginWrapper.java
@@ -131,11 +131,11 @@ public class PluginWrapper {
         return "PluginWrapper [descriptor=" + descriptor + ", pluginPath=" + pluginPath + "]";
     }
 
-    void setPluginState(PluginState pluginState) {
+    public void setPluginState(PluginState pluginState) {
         this.pluginState = pluginState;
     }
 
-    void setPluginFactory(PluginFactory pluginFactory) {
+    public void setPluginFactory(PluginFactory pluginFactory) {
         this.pluginFactory = pluginFactory;
     }
 


### PR DESCRIPTION
## Motivation
I'm currently faced with the problem that my custom plugin manager is unable to set the plugin factory and state since the methods are not public. The only way how I can manage this is to move my manager to the `org.pf4j` package.

## Example Usecase

My manager provides this method to quickly deploy plugins without the need to load them from filesystem:
```java
private PluginWrapper loadPlugin(Class<?> clazz, String pluginId) {
    MeshPluginDescriptor pluginDescriptor = new MeshPluginDescriptorImpl(pluginId, clazz);

    log.debug("Found descriptor {}", pluginDescriptor);
    String pluginClassName = clazz.getName();
    log.debug("Class '{}' for plugin", pluginClassName);

    // create the plugin wrapper
    log.debug("Creating wrapper for plugin '{}'", pluginClassName);
    PluginWrapper pluginWrapper = new PluginWrapper(this, pluginDescriptor, null, clazz.getClassLoader());
    pluginWrapper.setPluginFactory(getPluginFactory());

    // test for disabled plugin
    if (isPluginDisabled(pluginDescriptor.getPluginId())) {
	    log.info("Plugin '{}' is disabled", pluginClassName);
	    pluginWrapper.setPluginState(PluginState.DISABLED);
    }

    // validate the plugin
    if (!isPluginValid(pluginWrapper)) {
	    log.warn("Plugin '{}' is invalid and it will be disabled", pluginClassName);
	    pluginWrapper.setPluginState(PluginState.DISABLED);
    }

    log.debug("Created wrapper '{}' for plugin '{}'", pluginWrapper, pluginClassName);

    // add plugin to the list with plugins
    plugins.put(pluginId, pluginWrapper);
    getUnresolvedPlugins().add(pluginWrapper);

    // add plugin class loader to the list with class loaders
    getPluginClassLoaders().put(pluginId, clazz.getClassLoader());

    resolvePlugins();

    return pluginWrapper;
}
```
