### PR TITLE
adds equals/hashCode to some data classes

### DIFF
--- a/pf4j/src/main/java/org/pf4j/DefaultPluginDescriptor.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginDescriptor.java
@@ -18,6 +18,7 @@ package org.pf4j;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Decebal Suiu
@@ -196,4 +197,23 @@ public class DefaultPluginDescriptor implements PluginDescriptor {
         return this;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DefaultPluginDescriptor)) return false;
+        DefaultPluginDescriptor that = (DefaultPluginDescriptor) o;
+        return Objects.equals(pluginId, that.pluginId) &&
+            Objects.equals(pluginDescription, that.pluginDescription) &&
+            Objects.equals(pluginClass, that.pluginClass) &&
+            Objects.equals(version, that.version) &&
+            Objects.equals(requires, that.requires) &&
+            Objects.equals(provider, that.provider) &&
+            dependencies.equals(that.dependencies) &&
+            Objects.equals(license, that.license);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginId, pluginDescription, pluginClass, version, requires, provider, dependencies, license);
+    }
 }

--- a/pf4j/src/main/java/org/pf4j/PluginClasspath.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClasspath.java
@@ -18,6 +18,7 @@ package org.pf4j;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -60,4 +61,17 @@ public class PluginClasspath {
         return this;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PluginClasspath)) return false;
+        PluginClasspath that = (PluginClasspath) o;
+        return classesDirectories.equals(that.classesDirectories) &&
+            jarsDirectories.equals(that.jarsDirectories);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classesDirectories, jarsDirectories);
+    }
 }

--- a/pf4j/src/main/java/org/pf4j/PluginDependency.java
+++ b/pf4j/src/main/java/org/pf4j/PluginDependency.java
@@ -15,6 +15,8 @@
  */
 package org.pf4j;
 
+import java.util.Objects;
+
 /**
  * @author Decebal Suiu
  */
@@ -61,4 +63,18 @@ public class PluginDependency {
             + optional + "]";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PluginDependency)) return false;
+        PluginDependency that = (PluginDependency) o;
+        return optional == that.optional &&
+            pluginId.equals(that.pluginId) &&
+            pluginVersionSupport.equals(that.pluginVersionSupport);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginId, pluginVersionSupport, optional);
+    }
 }

--- a/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
@@ -33,32 +33,44 @@ public class PluginDependencyTest {
     @Test
     public void testPluginDependecy() {
         PluginDependency instance = new PluginDependency("test");
+        PluginDependency instance2 = new PluginDependency("test");
+        assertEquals(instance, instance2);
         assertEquals("test", instance.getPluginId());
         assertEquals("*", instance.getPluginVersionSupport());
         assertFalse(instance.isOptional());
 
         instance = new PluginDependency("test@");
+        instance2 = new PluginDependency("test@");
+        assertEquals(instance, instance2);
         assertEquals("test", instance.getPluginId());
         assertEquals("*", instance.getPluginVersionSupport());
         assertFalse(instance.isOptional());
 
         instance = new PluginDependency("test?");
+        instance2 = new PluginDependency("test?");
+        assertEquals(instance, instance2);
         assertEquals("test", instance.getPluginId());
         assertEquals("*", instance.getPluginVersionSupport());
         assertTrue(instance.isOptional());
 
         instance = new PluginDependency("test?@");
+        instance2 = new PluginDependency("test?@");
+        assertEquals(instance, instance2);
         assertEquals("test", instance.getPluginId());
         assertEquals("*", instance.getPluginVersionSupport());
         assertTrue(instance.isOptional());
 
         instance = new PluginDependency("test@1.0");
+        instance2 = new PluginDependency("test@1.0");
+        assertEquals(instance, instance2);
         assertEquals("test", instance.getPluginId());
         assertEquals("1.0", instance.getPluginVersionSupport());
         assertFalse(instance.isOptional());
         assertEquals("PluginDependency [pluginId=test, pluginVersionSupport=1.0, optional=false]", instance.toString());
 
         instance = new PluginDependency("test?@1.0");
+        instance2 = new PluginDependency("test?@1.0");
+        assertEquals(instance, instance2);
         assertEquals("test", instance.getPluginId());
         assertEquals("1.0", instance.getPluginVersionSupport());
         assertTrue(instance.isOptional());


### PR DESCRIPTION
We have extended DefaultPluginDescriptor to add some extra attributes
and not having equals/hashCode implemented makes it a bit tough to
write good tests around our PluginDescriptorFinder implementation.

This just adds IntelliJ generated equals and hashCode to
DefaultPluginDescriptor, PluginDependency, and PluginClasspath.