### PR TITLE
Relax the concept of extension point

### DIFF
--- a/pf4j/src/main/java/org/pf4j/Extension.java
+++ b/pf4j/src/main/java/org/pf4j/Extension.java
@@ -45,7 +45,7 @@ public @interface Extension {
      *
      * @return classes of extension points, that are implemented by this extension
      */
-    Class<? extends ExtensionPoint>[] points() default {};
+    Class<?>[] points() default {};
 
     /**
      * An array of plugin IDs, that have to be available in order to load this extension.

--- a/pf4j/src/test/java/org/pf4j/ExtensionAnnotationProcessorTest.java
+++ b/pf4j/src/test/java/org/pf4j/ExtensionAnnotationProcessorTest.java
@@ -146,11 +146,23 @@ public class ExtensionAnnotationProcessorTest {
     }
 
     @Test
+    public void compileWithErrorNoExtensionPoint() {
+        ExtensionAnnotationProcessor processor = new ExtensionAnnotationProcessor();
+        Compilation compilation = javac().withProcessors(processor).withOptions("-A" + ExtensionAnnotationProcessor.CHECK_EXTENSION_POINT)
+            .compile(Greeting, WhazzupGreeting_NoExtensionPoint);
+        assertThat(compilation).failed();
+        assertThat(compilation).hadErrorContaining("it doesn't implement ExtensionPoint")
+            .inFile(WhazzupGreeting_NoExtensionPoint)
+            .onLine(5)
+            .atColumn(8);
+    }
+
+    @Test
     public void compileWithError() {
         ExtensionAnnotationProcessor processor = new ExtensionAnnotationProcessor();
         Compilation compilation = javac().withProcessors(processor).compile(Greeting, WhazzupGreeting_NoExtensionPoint);
         assertThat(compilation).failed();
-        assertThat(compilation).hadErrorContaining("it doesn't implement ExtensionPoint")
+        assertThat(compilation).hadErrorContaining("it doesn't implement any interface")
             .inFile(WhazzupGreeting_NoExtensionPoint)
             .onLine(5)
             .atColumn(8);


### PR DESCRIPTION
These changes will solve some of the issues discussed in #358.
It contains:
- relax the type of `Extension#points` field (see https://github.com/pf4j/pf4j/issues/289#issuecomment-556436265)
- `ExtensionAnnotationProcessor` check that an extension implements `ExtensionPoint` interface marker only if `pf4j.checkExtensionPoint` is present. By default the check is disabled