### PR TITLE
Failed plugin state added. When plugin failed to start previous state was kept

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -330,9 +330,11 @@ public abstract class AbstractPluginManager implements PluginManager {
                     log.info("Start plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
                     pluginWrapper.getPlugin().start();
                     pluginWrapper.setPluginState(PluginState.STARTED);
+                    pluginWrapper.setFailedException(null);
                     startedPlugins.add(pluginWrapper);
                 } catch (Exception e) {
                     pluginWrapper.setPluginState(PluginState.FAILED);
+                    pluginWrapper.setFailedException(e);
                     log.error(e.getMessage(), e);
                 } finally {
                     firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -331,10 +331,11 @@ public abstract class AbstractPluginManager implements PluginManager {
                     pluginWrapper.getPlugin().start();
                     pluginWrapper.setPluginState(PluginState.STARTED);
                     startedPlugins.add(pluginWrapper);
-
-                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
                 } catch (Exception e) {
+                    pluginWrapper.setPluginState(PluginState.FAILED);
                     log.error(e.getMessage(), e);
+                } finally {
+                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
                 }
             }
         }

--- a/pf4j/src/main/java/org/pf4j/PluginState.java
+++ b/pf4j/src/main/java/org/pf4j/PluginState.java
@@ -24,12 +24,12 @@ public enum PluginState {
      * The runtime knows the plugin is there. It knows about the plugin path, the plugin descriptor.
      */
     CREATED("CREATED"),
-    
+
     /**
      * The plugin cannot be used.
      */
     DISABLED("DISABLED"),
-    
+
     /**
      * The plugin is created. All the dependencies are created and resolved.
      * The plugin is ready to be started.
@@ -44,7 +44,12 @@ public enum PluginState {
     /**
      * The {@link Plugin#stop()} has executed.
      */
-    STOPPED("STOPPED");
+    STOPPED("STOPPED"),
+
+    /**
+     * Plugin failed to start.
+     */
+    FAILED("FAILED");
 
     private String status;
 

--- a/pf4j/src/main/java/org/pf4j/PluginWrapper.java
+++ b/pf4j/src/main/java/org/pf4j/PluginWrapper.java
@@ -32,6 +32,8 @@ public class PluginWrapper {
     private PluginState pluginState;
     private RuntimeMode runtimeMode;
 
+    private Exception failedException;
+
     Plugin plugin; // cache
 
     public PluginWrapper(PluginManager pluginManager, PluginDescriptor descriptor, Path pluginPath, ClassLoader pluginClassLoader) {
@@ -139,4 +141,11 @@ public class PluginWrapper {
         this.pluginFactory = pluginFactory;
     }
 
+    public Exception getFailedException() {
+        return failedException;
+    }
+
+    public void setFailedException(Exception failedException) {
+        this.failedException = failedException;
+    }
 }

--- a/pf4j/src/main/java/org/pf4j/PluginWrapper.java
+++ b/pf4j/src/main/java/org/pf4j/PluginWrapper.java
@@ -141,6 +141,10 @@ public class PluginWrapper {
         this.pluginFactory = pluginFactory;
     }
 
+    /**
+     * Returns the exception with which the plugin fails to start.
+     * See @{link PluginStatus#FAILED}.
+     */
     public Exception getFailedException() {
         return failedException;
     }
@@ -148,4 +152,5 @@ public class PluginWrapper {
     public void setFailedException(Exception failedException) {
         this.failedException = failedException;
     }
+
 }


### PR DESCRIPTION
There is no easy way how to distinguish FAILED and STOPPED/RESOLVED plugins. 