### PR TITLE
PluginClassLoader does not resolve classpath resources from plugin dependencies

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -15,10 +15,6 @@
  */
 package org.pf4j;
 
-import org.pf4j.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,6 +27,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.pf4j.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class implements the boilerplate plugin code that any {@link PluginManager}

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -208,8 +208,7 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     @Override
-    public Enumeration<URL> getResources(String name) throws IOException {
-        
+    public Enumeration<URL> getResources(String name) throws IOException {  
     	List<URL> resources = new ArrayList<>();
 
     	if (!parentFirst) {
@@ -288,9 +287,7 @@ public class PluginClassLoader extends URLClassLoader {
             if (classLoader == null || dependency.isOptional()) {
                 continue;
             }
-
             results.addAll(Collections.list(classLoader.findResources(name)));
-            
         }
 
         return results;

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -252,7 +252,7 @@ public class PluginClassLoader extends URLClassLoader {
             }
 
             URL url = classLoader.getResource(name);
-            if(Objects.nonNull(url)) {
+            if (Objects.nonNull(url)) {
             	return url;
             }
         }
@@ -273,7 +273,7 @@ public class PluginClassLoader extends URLClassLoader {
             }
 
             URL url = classLoader.getResource(name);
-            if(Objects.nonNull(url)) {
+            if (Objects.nonNull(url)) {
             	results.add(url);
             }
         }

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -226,7 +226,7 @@ public class PluginClassLoader extends URLClassLoader {
             ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null && dependency.isOptional()) {
+            if (classLoader == null || dependency.isOptional()) {
                 continue;
             }
 
@@ -247,7 +247,7 @@ public class PluginClassLoader extends URLClassLoader {
             ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null && dependency.isOptional()) {
+            if (classLoader == null || dependency.isOptional()) {
                 continue;
             }
 
@@ -268,7 +268,7 @@ public class PluginClassLoader extends URLClassLoader {
             ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null && dependency.isOptional()) {
+            if (classLoader == null || dependency.isOptional()) {
                 continue;
             }
 

--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -42,11 +42,16 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PluginClassLoaderTest {
 
-    private DefaultPluginManager pluginManager;
+    private TestPluginManager pluginManager;
+    private TestPluginManager pluginManagerParentFirst;
+    private DefaultPluginDescriptor pluginDependencyDescriptor;
     private DefaultPluginDescriptor pluginDescriptor;
 
     private PluginClassLoader parentLastPluginClassLoader;
     private PluginClassLoader parentFirstPluginClassLoader;
+    
+    private PluginClassLoader parentLastPluginDependencyClassLoader;
+    private PluginClassLoader parentFirstPluginDependencyClassLoader;
 
     @TempDir
     Path pluginsPath;
@@ -62,6 +67,8 @@ public class PluginClassLoaderTest {
         }
 
         createFile(parentClassPathBase.resolve("META-INF").resolve("file-only-in-parent"));
+        createFile(parentClassPathBase.resolve("META-INF").resolve("file-in-both-parent-and-dependency-and-plugin"));
+        createFile(parentClassPathBase.resolve("META-INF").resolve("file-in-both-parent-and-dependency"));
         createFile(parentClassPathBase.resolve("META-INF").resolve("file-in-both-parent-and-plugin"));
     }
 
@@ -69,7 +76,7 @@ public class PluginClassLoaderTest {
         File file = pathToFile.toFile();
 
         file.deleteOnExit();
-        assertTrue(file.createNewFile(), "failed to create '" + pathToFile + "'");
+        assertTrue(file.exists() || file.createNewFile(), "failed to create '" + pathToFile + "'");
         try (PrintWriter printWriter = new PrintWriter(file)) {
             printWriter.write("parent");
         }
@@ -77,13 +84,57 @@ public class PluginClassLoaderTest {
 
     @BeforeEach
     void setUp() throws IOException {
-        pluginManager = new DefaultPluginManager(pluginsPath);
+        pluginManager = new TestPluginManager(pluginsPath);
+        pluginManagerParentFirst = new TestPluginManager(pluginsPath);
 
+        pluginDependencyDescriptor = new DefaultPluginDescriptor();
+        pluginDependencyDescriptor.setPluginId("myDependency");
+        pluginDependencyDescriptor.setPluginVersion("1.2.3");
+        pluginDependencyDescriptor.setPluginDescription("My plugin");
+        pluginDependencyDescriptor.setDependencies("");
+        pluginDependencyDescriptor.setProvider("Me");
+        pluginDependencyDescriptor.setRequires("5.0.0");
+
+        
+        Path pluginDependencyPath = pluginsPath.resolve(pluginDependencyDescriptor.getPluginId() + "-" + pluginDependencyDescriptor.getVersion() + ".zip");
+        PluginZip pluginDependencyZip = new PluginZip.Builder(pluginDependencyPath, pluginDependencyDescriptor.getPluginId())
+                .pluginVersion(pluginDependencyDescriptor.getVersion())
+                .addFile(Paths.get("classes/META-INF/dependency-file"), "dependency")
+                .addFile(Paths.get("classes/META-INF/file-in-both-parent-and-dependency-and-plugin"), "dependency")
+                .addFile(Paths.get("classes/META-INF/file-in-both-parent-and-dependency"), "dependency")
+                .build();
+
+        FileUtils.expandIfZip(pluginDependencyZip.path());
+
+        PluginClasspath pluginDependencyClasspath = new DefaultPluginClasspath();
+
+        parentLastPluginDependencyClassLoader = new PluginClassLoader(pluginManager, pluginDependencyDescriptor, PluginClassLoaderTest.class.getClassLoader());
+        parentFirstPluginDependencyClassLoader = new PluginClassLoader(pluginManagerParentFirst, pluginDependencyDescriptor, PluginClassLoaderTest.class.getClassLoader(), true);
+        
+        pluginManager.addClassLoader(pluginDependencyDescriptor.getPluginId(), parentLastPluginDependencyClassLoader);
+        pluginManagerParentFirst.addClassLoader(pluginDependencyDescriptor.getPluginId(), parentFirstPluginDependencyClassLoader);
+        
+        
+        for (String classesDirectory : pluginDependencyClasspath.getClassesDirectories()) {
+            File classesDirectoryFile = pluginDependencyZip.unzippedPath().resolve(classesDirectory).toFile();
+            parentLastPluginDependencyClassLoader.addFile(classesDirectoryFile);
+            parentFirstPluginDependencyClassLoader.addFile(classesDirectoryFile);
+        }
+
+        for (String jarsDirectory : pluginDependencyClasspath.getJarsDirectories()) {
+            Path jarsDirectoryPath = pluginDependencyZip.unzippedPath().resolve(jarsDirectory);
+            List<File> jars = FileUtils.getJars(jarsDirectoryPath);
+            for (File jar : jars) {
+            	parentLastPluginDependencyClassLoader.addFile(jar);
+            	parentFirstPluginDependencyClassLoader.addFile(jar);
+            }
+        }
+        
         pluginDescriptor = new DefaultPluginDescriptor();
         pluginDescriptor.setPluginId("myPlugin");
         pluginDescriptor.setPluginVersion("1.2.3");
         pluginDescriptor.setPluginDescription("My plugin");
-        pluginDescriptor.setDependencies("bar, baz");
+        pluginDescriptor.setDependencies("myDependency");
         pluginDescriptor.setProvider("Me");
         pluginDescriptor.setRequires("5.0.0");
 
@@ -91,6 +142,7 @@ public class PluginClassLoaderTest {
         PluginZip pluginZip = new PluginZip.Builder(pluginPath, pluginDescriptor.getPluginId())
                 .pluginVersion(pluginDescriptor.getVersion())
                 .addFile(Paths.get("classes/META-INF/plugin-file"), "plugin")
+                .addFile(Paths.get("classes/META-INF/file-in-both-parent-and-dependency-and-plugin"), "plugin")
                 .addFile(Paths.get("classes/META-INF/file-in-both-parent-and-plugin"), "plugin")
                 .build();
 
@@ -101,6 +153,9 @@ public class PluginClassLoaderTest {
         parentLastPluginClassLoader = new PluginClassLoader(pluginManager, pluginDescriptor, PluginClassLoaderTest.class.getClassLoader());
         parentFirstPluginClassLoader = new PluginClassLoader(pluginManager, pluginDescriptor, PluginClassLoaderTest.class.getClassLoader(), true);
 
+        pluginManager.addClassLoader(pluginDescriptor.getPluginId(), parentLastPluginClassLoader);
+        pluginManagerParentFirst.addClassLoader(pluginDescriptor.getPluginId(), parentFirstPluginClassLoader);
+        
         for (String classesDirectory : pluginClasspath.getClassesDirectories()) {
             File classesDirectoryFile = pluginZip.unzippedPath().resolve(classesDirectory).toFile();
             parentLastPluginClassLoader.addFile(classesDirectoryFile);
@@ -120,7 +175,10 @@ public class PluginClassLoaderTest {
     @AfterEach
     void tearDown() {
         pluginManager = null;
+        pluginDependencyDescriptor = null;
         pluginDescriptor = null;
+        parentLastPluginClassLoader =  null;
+        parentFirstPluginClassLoader = null;
     }
 
     @Test
@@ -132,6 +190,7 @@ public class PluginClassLoaderTest {
     void parentFirstGetResourceNonExisting() {
         assertNull(parentFirstPluginClassLoader.getResource("META-INF/non-existing-file"));
     }
+   
 
     @Test
     void parentLastGetResourceExistsInParent() throws IOException, URISyntaxException {
@@ -144,7 +203,7 @@ public class PluginClassLoaderTest {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-only-in-parent");
         assertFirstLine("parent", resource);
     }
-
+    
     @Test
     void parentLastGetResourceExistsOnlyInPlugin() throws IOException, URISyntaxException {
         URL resource = parentLastPluginClassLoader.getResource("META-INF/plugin-file");
@@ -156,6 +215,18 @@ public class PluginClassLoaderTest {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/plugin-file");
         assertFirstLine("plugin", resource);
     }
+    
+    @Test
+    void parentLastGetResourceExistsOnlyInDependnecy() throws IOException, URISyntaxException {
+        URL resource = parentLastPluginClassLoader.getResource("META-INF/dependency-file");
+        assertFirstLine("dependency", resource);
+    }
+
+    @Test
+    void parentFirstGetResourceExistsOnlyInDependency() throws IOException, URISyntaxException {
+        URL resource = parentFirstPluginClassLoader.getResource("META-INF/dependency-file");
+        assertFirstLine("dependency", resource);
+    }
 
     @Test
     void parentLastGetResourceExistsInBothParentAndPlugin() throws URISyntaxException, IOException {
@@ -166,6 +237,18 @@ public class PluginClassLoaderTest {
     @Test
     void parentFirstGetResourceExistsInBothParentAndPlugin() throws URISyntaxException, IOException {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-in-both-parent-and-plugin");
+        assertFirstLine("parent", resource);
+    }
+    
+    @Test
+    void parentLastGetResourceExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
+        URL resource = parentLastPluginClassLoader.getResource("META-INF/file-in-both-parent-and-dependency-and-plugin");
+        assertFirstLine("plugin", resource);
+    }
+    
+    @Test
+    void parentFirstGetResourceExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
+        URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-in-both-parent-and-dependency-and-plugin");
         assertFirstLine("parent", resource);
     }
 
@@ -192,6 +275,18 @@ public class PluginClassLoaderTest {
     }
 
     @Test
+    void parentLastGetResourcesExistsOnlyInDependency() throws IOException, URISyntaxException {
+        Enumeration<URL> resources = parentLastPluginClassLoader.getResources("META-INF/dependency-file");
+        assertNumberOfResourcesAndFirstLineOfFirstElement(1, "dependency", resources);
+    }
+
+    @Test
+    void parentFirstGetResourcesExistsOnlyInDependency() throws IOException, URISyntaxException {
+        Enumeration<URL> resources = parentFirstPluginClassLoader.getResources("META-INF/dependency-file");
+        assertNumberOfResourcesAndFirstLineOfFirstElement(1, "dependency", resources);
+    }
+    
+    @Test
     void parentLastGetResourcesExistsOnlyInPlugin() throws IOException, URISyntaxException {
         Enumeration<URL> resources = parentLastPluginClassLoader.getResources("META-INF/plugin-file");
         assertNumberOfResourcesAndFirstLineOfFirstElement(1, "plugin", resources);
@@ -214,6 +309,18 @@ public class PluginClassLoaderTest {
         Enumeration<URL> resources = parentFirstPluginClassLoader.getResources("META-INF/file-in-both-parent-and-plugin");
         assertNumberOfResourcesAndFirstLineOfFirstElement(2, "parent", resources);
     }
+    
+    @Test
+    void parentLastGetResourcesExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
+        Enumeration<URL> resources = parentLastPluginClassLoader.getResources("META-INF/file-in-both-parent-and-dependency-and-plugin");
+        assertNumberOfResourcesAndFirstLineOfFirstElement(3, "plugin", resources);
+    }
+
+    @Test
+    void parentFirstGetResourcesExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
+        Enumeration<URL> resources = parentFirstPluginClassLoader.getResources("META-INF/file-in-both-parent-and-dependency-and-plugin");
+        assertNumberOfResourcesAndFirstLineOfFirstElement(3, "parent", resources);
+    }
 
     private static void assertFirstLine(String expected, URL resource) throws URISyntaxException, IOException {
         assertNotNull(resource);
@@ -226,5 +333,16 @@ public class PluginClassLoaderTest {
 
         URL firstResource = list.get(0);
         assertEquals(expectedFirstLine, Files.readAllLines(Paths.get(firstResource.toURI())).get(0));
+    }
+    
+    class TestPluginManager extends DefaultPluginManager {
+    	
+    	public TestPluginManager(Path pluginsPath) {
+			super(pluginsPath);
+		}
+
+		void addClassLoader(String pluginId, PluginClassLoader classLoader) {
+    		getPluginClassLoaders().put(pluginId, classLoader);
+    	}
     }
 }

--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -190,20 +190,19 @@ public class PluginClassLoaderTest {
     void parentFirstGetResourceNonExisting() {
         assertNull(parentFirstPluginClassLoader.getResource("META-INF/non-existing-file"));
     }
-   
 
     @Test
     void parentLastGetResourceExistsInParent() throws IOException, URISyntaxException {
         URL resource = parentLastPluginClassLoader.getResource("META-INF/file-only-in-parent");
         assertFirstLine("parent", resource);
     }
-
+    
     @Test
     void parentFirstGetResourceExistsInParent() throws IOException, URISyntaxException {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-only-in-parent");
         assertFirstLine("parent", resource);
     }
-    
+
     @Test
     void parentLastGetResourceExistsOnlyInPlugin() throws IOException, URISyntaxException {
         URL resource = parentLastPluginClassLoader.getResource("META-INF/plugin-file");


### PR DESCRIPTION
I've been working with Pf4j and Spring and have come across an issue when using hierarchical plugins and Spring. In my project, I have a plugin that provides an SSH server component to my application. I then have several other plugins that depend on this, that provide command implementations to the SSH server.

The command implementations depend on an Interface in the SSH server plugin. It is not an ExtensionPoint, it is simply an interface and the Spring components are created by the SpringPlugin's during the creation of the ApplicationContext.

When using this setup, spring initialization fails with the current 3.3.0-SNAPSHOT because Spring attempts to load the class of my interface using getResource (I assume it does this because of all the magical stuff Spring does). This only checks the plugin and the parent class loaders, it does not consult plugin dependencies, unlike loadClass which does.

I am of course able to use and declare the interface as an ExtensionPoint and therefore not rely on Spring to create the component initially and instead inject it, but I think the fix is still valid. The fix is in the pf4j core and not pf4j-spring so its a core issue of the PluginClassLoader. If you are allowing classes to be utilized from plugin dependencies then IMHO it should be possible to access resources in those dependencies too.

This pull request contains a fix for this scenario by adding support for resources from plugin dependencies. 

It also contains a fix for an NPE that I started seeing in tests after implementing this change. The loadClassFromDependencies method checks for the nullness of classLoader, but only skips if the dependency is optional. Resulting in a NullPointerException when classLoader==null and the dependency is not optional.

