### PR TITLE
Sort files using last modified as long

### DIFF
--- a/pf4j/src/main/java/org/pf4j/BasePluginRepository.java
+++ b/pf4j/src/main/java/org/pf4j/BasePluginRepository.java
@@ -48,7 +48,7 @@ public class BasePluginRepository implements PluginRepository {
         this.filter = filter;
 
         // last modified file is first
-        this.comparator = (o1, o2) -> (int) (o2.lastModified() - o1.lastModified());
+        this.comparator = Comparator.comparingLong(File::lastModified);
     }
 
     public void setFilter(FileFilter filter) {

--- a/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
@@ -18,6 +18,7 @@ package org.pf4j;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import com.google.testing.compile.Compilation;
+import java.util.Comparator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -238,7 +239,7 @@ public class AbstractExtensionFinderTest {
 
         public Map<String, Class<?>> loadClasses(List<JavaFileObject> classes) throws IOException {
             // Sort generated ".class" by lastModified field
-            classes.sort((c1, c2) -> (int) (c1.getLastModified() - c2.getLastModified()));
+            classes.sort(Comparator.comparingLong(JavaFileObject::getLastModified));
 
             // Load classes
             Map<String, Class<?>> loadedClasses = new HashMap<>(classes.size());


### PR DESCRIPTION
This prevents downcasting errors where files can have a negative time, causing TimSort to go haywire and throw an exception.