### PR TITLE
Fix wrong logical condition (optional dependencies are always skipped)

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -326,10 +326,10 @@ public abstract class AbstractPluginManager implements PluginManager {
                     pluginWrapper.setPluginState(PluginState.STARTED);
                     pluginWrapper.setFailedException(null);
                     startedPlugins.add(pluginWrapper);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     pluginWrapper.setPluginState(PluginState.FAILED);
                     pluginWrapper.setFailedException(e);
-                    log.error(e.getMessage(), e);
+                    log.error("Unable to start plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()), e);
                 } finally {
                     firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
                 }

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -365,7 +365,10 @@ public abstract class AbstractPluginManager implements PluginManager {
         }
 
         for (PluginDependency dependency : pluginDescriptor.getDependencies()) {
-            startPlugin(dependency.getPluginId());
+            // start dependency only if it marked as required (non optional) or if it optional and loaded
+            if (!dependency.isOptional() || plugins.containsKey(dependency.getPluginId())) {
+                startPlugin(dependency.getPluginId());
+            }
         }
 
         log.info("Start plugin '{}'", getPluginLabel(pluginDescriptor));

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -15,22 +15,16 @@
  */
 package org.pf4j;
 
+import org.pf4j.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.pf4j.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.*;
 
 /**
  * This class implements the boilerplate plugin code that any {@link PluginManager}
@@ -243,7 +237,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         return unloadPlugin(pluginId, true);
     }
 
-    private boolean unloadPlugin(String pluginId, boolean unloadDependents) {
+    protected boolean unloadPlugin(String pluginId, boolean unloadDependents) {
         try {
             if (unloadDependents) {
                 List<String> dependents = dependencyResolver.getDependents(pluginId);
@@ -418,7 +412,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         return stopPlugin(pluginId, true);
     }
 
-    private PluginState stopPlugin(String pluginId, boolean stopDependents) {
+    protected PluginState stopPlugin(String pluginId, boolean stopDependents) {
         checkPluginId(pluginId);
 
         PluginWrapper pluginWrapper = getPlugin(pluginId);
@@ -454,7 +448,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         return pluginWrapper.getPluginState();
     }
 
-    private void checkPluginId(String pluginId) {
+    protected void checkPluginId(String pluginId) {
         if (!plugins.containsKey(pluginId)) {
             throw new IllegalArgumentException(String.format("Unknown pluginId %s", pluginId));
         }
@@ -913,7 +907,7 @@ public abstract class AbstractPluginManager implements PluginManager {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> List<Class<? extends T>> getExtensionClasses(List<ExtensionWrapper<T>> extensionsWrapper) {
+    protected <T> List<Class<? extends T>> getExtensionClasses(List<ExtensionWrapper<T>> extensionsWrapper) {
         List<Class<? extends T>> extensionClasses = new ArrayList<>(extensionsWrapper.size());
         for (ExtensionWrapper<T> extensionWrapper : extensionsWrapper) {
             Class<T> c = (Class<T>) extensionWrapper.getDescriptor().extensionClass;
@@ -923,7 +917,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         return extensionClasses;
     }
 
-    private <T> List<T> getExtensions(List<ExtensionWrapper<T>> extensionsWrapper) {
+    protected <T> List<T> getExtensions(List<ExtensionWrapper<T>> extensionsWrapper) {
         List<T> extensions = new ArrayList<>(extensionsWrapper.size());
         for (ExtensionWrapper<T> extensionWrapper : extensionsWrapper) {
             try {

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -24,7 +24,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This class implements the boilerplate plugin code that any {@link PluginManager}

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -15,19 +15,14 @@
  */
 package org.pf4j;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.*;
 
 /**
  * One instance of this class should be created by plugin manager for every available plug-in.
@@ -177,7 +172,7 @@ public class PluginClassLoader extends URLClassLoader {
                 log.trace("Found resource '{}' in plugin classpath", name);
                 return url;
             }
-            
+
             url = findResourceFromDependencies(name);
             if (url != null) {
                 log.trace("Found resource '{}' in plugin dependencies", name);
@@ -197,41 +192,41 @@ public class PluginClassLoader extends URLClassLoader {
             log.trace("Couldn't find resource '{}' in parent", name);
 
             url = findResourceFromDependencies(name);
-           
+
             if (url != null) {
                log.trace("Found resource '{}' in dependencies", name);
                return url;
-            }  
-            
+            }
+
             return findResource(name);
         }
     }
 
     @Override
-    public Enumeration<URL> getResources(String name) throws IOException {  
+    public Enumeration<URL> getResources(String name) throws IOException {
     	List<URL> resources = new ArrayList<>();
 
     	if (!parentFirst) {
-            
+
             resources.addAll(Collections.list(findResources(name)));
 
             resources.addAll(findResourcesFromDependencies(name));
-            
+
             if (getParent() != null) {
                 resources.addAll(Collections.list(getParent().getResources(name)));
             }
 
         } else {
-        	
+
         	if (getParent() != null) {
                 resources.addAll(Collections.list(getParent().getResources(name)));
             }
-        	
+
         	resources.addAll(findResourcesFromDependencies(name));
-        	
+
         	resources.addAll(Collections.list(super.findResources(name)));
         }
-    	
+
     	return Collections.enumeration(resources);
     }
 
@@ -242,8 +237,14 @@ public class PluginClassLoader extends URLClassLoader {
             ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null || dependency.isOptional()) {
-                continue;
+            if (classLoader == null) {
+                if (dependency.isOptional()) {
+                    continue;
+                } else {
+                    throw new PluginRuntimeException(
+                        String.format("Unable to load class '%s'. Required dependency '%s' not loaded.",
+                            className, dependency.getPluginId()));
+                }
             }
 
             try {
@@ -255,7 +256,7 @@ public class PluginClassLoader extends URLClassLoader {
 
         return null;
     }
-    
+
     private URL findResourceFromDependencies(String name) {
         log.trace("Search in dependencies for resource '{}'", name);
         List<PluginDependency> dependencies = pluginDescriptor.getDependencies();
@@ -263,8 +264,14 @@ public class PluginClassLoader extends URLClassLoader {
             PluginClassLoader classLoader = (PluginClassLoader) pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null || dependency.isOptional()) {
-                continue;
+            if (classLoader == null) {
+                if (dependency.isOptional()) {
+                    continue;
+                } else {
+                    throw new PluginRuntimeException(
+                        String.format("Unable to find resource '%s'. Required dependency '%s' not loaded.",
+                            name, dependency.getPluginId()));
+                }
             }
 
             URL url = classLoader.findResource(name);
@@ -275,7 +282,7 @@ public class PluginClassLoader extends URLClassLoader {
 
         return null;
     }
-    
+
     private Collection<URL> findResourcesFromDependencies(String name) throws IOException {
         log.trace("Search in dependencies for resources '{}'", name);
         List<URL> results = new ArrayList<>();
@@ -284,9 +291,16 @@ public class PluginClassLoader extends URLClassLoader {
             PluginClassLoader classLoader = (PluginClassLoader) pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null || dependency.isOptional()) {
-                continue;
+            if (classLoader == null) {
+                if (dependency.isOptional()) {
+                    continue;
+                } else {
+                    throw new PluginRuntimeException(
+                        String.format("Unable to find resource '%s'. Required dependency '%s' not loaded.",
+                            name, dependency.getPluginId()));
+                }
             }
+
             results.addAll(Collections.list(classLoader.findResources(name)));
         }
 

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -22,7 +22,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * One instance of this class should be created by plugin manager for every available plug-in.
@@ -237,14 +242,8 @@ public class PluginClassLoader extends URLClassLoader {
             ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null) {
-                if (dependency.isOptional()) {
-                    continue;
-                } else {
-                    throw new PluginRuntimeException(
-                        String.format("Unable to load class '%s'. Required dependency '%s' not loaded.",
-                            className, dependency.getPluginId()));
-                }
+            if (classLoader == null && dependency.isOptional()) {
+                continue;
             }
 
             try {
@@ -264,14 +263,8 @@ public class PluginClassLoader extends URLClassLoader {
             PluginClassLoader classLoader = (PluginClassLoader) pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null) {
-                if (dependency.isOptional()) {
-                    continue;
-                } else {
-                    throw new PluginRuntimeException(
-                        String.format("Unable to find resource '%s'. Required dependency '%s' not loaded.",
-                            name, dependency.getPluginId()));
-                }
+            if (classLoader == null && dependency.isOptional()) {
+                continue;
             }
 
             URL url = classLoader.findResource(name);
@@ -291,14 +284,8 @@ public class PluginClassLoader extends URLClassLoader {
             PluginClassLoader classLoader = (PluginClassLoader) pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null) {
-                if (dependency.isOptional()) {
-                    continue;
-                } else {
-                    throw new PluginRuntimeException(
-                        String.format("Unable to find resource '%s'. Required dependency '%s' not loaded.",
-                            name, dependency.getPluginId()));
-                }
+            if (classLoader == null && dependency.isOptional()) {
+                continue;
             }
 
             results.addAll(Collections.list(classLoader.findResources(name)));

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -212,23 +212,18 @@ public class PluginClassLoader extends URLClassLoader {
     	List<URL> resources = new ArrayList<>();
 
     	if (!parentFirst) {
-
             resources.addAll(Collections.list(findResources(name)));
-
             resources.addAll(findResourcesFromDependencies(name));
 
             if (getParent() != null) {
                 resources.addAll(Collections.list(getParent().getResources(name)));
             }
-
         } else {
-
         	if (getParent() != null) {
                 resources.addAll(Collections.list(getParent().getResources(name)));
             }
 
         	resources.addAll(findResourcesFromDependencies(name));
-
         	resources.addAll(Collections.list(super.findResources(name)));
         }
 

--- a/pf4j/src/main/java/org/pf4j/PluginWrapper.java
+++ b/pf4j/src/main/java/org/pf4j/PluginWrapper.java
@@ -32,7 +32,7 @@ public class PluginWrapper {
     private PluginState pluginState;
     private RuntimeMode runtimeMode;
 
-    private Exception failedException;
+    private Throwable failedException;
 
     Plugin plugin; // cache
 
@@ -145,11 +145,11 @@ public class PluginWrapper {
      * Returns the exception with which the plugin fails to start.
      * See @{link PluginStatus#FAILED}.
      */
-    public Exception getFailedException() {
+    public Throwable getFailedException() {
         return failedException;
     }
 
-    public void setFailedException(Exception failedException) {
+    public void setFailedException(Throwable failedException) {
         this.failedException = failedException;
     }
 


### PR DESCRIPTION
Hi. There is an error in logical condition. Class loading from optional dependency is always skipped because of OR logical condition.
Also I have made some methods protected instead of private to make them usable in descendants, and added fix for starting optional dependencies. Those changes are based on use-case of pf4j library in my project. Thanks!