### PR TITLE
Make DefaultPluginDescriptor#addDependency usable

### DIFF
--- a/pf4j/src/main/java/org/pf4j/DefaultPluginDescriptor.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginDescriptor.java
@@ -16,7 +16,6 @@
 package org.pf4j;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -167,12 +166,11 @@ public class DefaultPluginDescriptor implements PluginDescriptor {
     }
 
     protected PluginDescriptor setDependencies(String dependencies) {
+        this.dependencies = new ArrayList<>();
+
         if (dependencies != null) {
             dependencies = dependencies.trim();
-            if (dependencies.isEmpty()) {
-                this.dependencies = Collections.emptyList();
-            } else {
-                this.dependencies = new ArrayList<>();
+            if (!dependencies.isEmpty()) {
                 String[] tokens = dependencies.split(",");
                 for (String dependency : tokens) {
                     dependency = dependency.trim();
@@ -180,12 +178,7 @@ public class DefaultPluginDescriptor implements PluginDescriptor {
                         this.dependencies.add(new PluginDependency(dependency));
                     }
                 }
-                if (this.dependencies.isEmpty()) {
-                    this.dependencies = Collections.emptyList();
-                }
             }
-        } else {
-            this.dependencies = Collections.emptyList();
         }
 
         return this;

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginDescriptorTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginDescriptorTest.java
@@ -1,0 +1,27 @@
+package org.pf4j;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DefaultPluginDescriptorTest {
+
+    @Test
+    void addDependency() {
+        // Given a descriptor with empty dependencies
+        DefaultPluginDescriptor descriptor = new DefaultPluginDescriptor();
+        descriptor.setDependencies("");
+        PluginDependency newDependency = new PluginDependency("test");
+
+        // When I add a dependency
+        descriptor.addDependency(newDependency);
+
+        // Then the dependency is added
+        List<PluginDependency> expected = new ArrayList<>();
+        expected.add(newDependency);
+        assertEquals(expected, descriptor.getDependencies());
+    }
+}

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginDescriptorTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginDescriptorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.pf4j;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Do not use Collections.emptyList() to create empty lists that should be writable,
otherwise an UnsupportedOperationException is thrown when you try to add something to that list.

This is especially annoying as it is not easy to fix in a subclass because of the asynchronous setter and getter of dependencies (Is that really a good idea?).