### PR TITLE
Bucketed caching in SingletonExtensionFactory

### DIFF
--- a/pf4j/src/main/java/org/pf4j/SingletonExtensionFactory.java
+++ b/pf4j/src/main/java/org/pf4j/SingletonExtensionFactory.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * An {@link ExtensionFactory} that always returns a specific instance.
@@ -36,13 +37,12 @@ public class SingletonExtensionFactory extends DefaultExtensionFactory {
     public SingletonExtensionFactory(String... extensionClassNames) {
         this.extensionClassNames = Arrays.asList(extensionClassNames);
 
-        cache = new HashMap<>(); // simple cache implementation
+        cache = new WeakHashMap<>(); // simple cache implementation
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> T create(Class<T> extensionClass) {
-
         String extensionClassName = extensionClass.getName();
         ClassLoader extensionClassLoader = extensionClass.getClassLoader();
 

--- a/pf4j/src/main/java/org/pf4j/SingletonExtensionFactory.java
+++ b/pf4j/src/main/java/org/pf4j/SingletonExtensionFactory.java
@@ -25,12 +25,13 @@ import java.util.Map;
  * Optional, you can specify the extension classes for which you want singletons.
  *
  * @author Decebal Suiu
+ * @author Ajith Kumar
  */
 public class SingletonExtensionFactory extends DefaultExtensionFactory {
 
     private final List<String> extensionClassNames;
 
-    private Map<String, Object> cache;
+    private Map<ClassLoader, Map<String, Object>> cache;
 
     public SingletonExtensionFactory(String... extensionClassNames) {
         this.extensionClassNames = Arrays.asList(extensionClassNames);
@@ -41,14 +42,23 @@ public class SingletonExtensionFactory extends DefaultExtensionFactory {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T create(Class<T> extensionClass) {
+
         String extensionClassName = extensionClass.getName();
-        if (cache.containsKey(extensionClassName)) {
-            return (T) cache.get(extensionClassName);
+        ClassLoader extensionClassLoader = extensionClass.getClassLoader();
+
+        if (!cache.containsKey(extensionClassLoader)) {
+            cache.put(extensionClassLoader, new HashMap<>());
+        }
+
+        Map<String, Object> classLoaderBucket = cache.get(extensionClassLoader);
+
+        if (classLoaderBucket.containsKey(extensionClassName)) {
+            return (T) classLoaderBucket.get(extensionClassName);
         }
 
         T extension = super.create(extensionClass);
         if (extensionClassNames.isEmpty() || extensionClassNames.contains(extensionClassName)) {
-            cache.put(extensionClassName, extension);
+            classLoaderBucket.put(extensionClassName, extension);
         }
 
         return extension;

--- a/pf4j/src/test/java/org/pf4j/SingletonExtensionFactoryTest.java
+++ b/pf4j/src/test/java/org/pf4j/SingletonExtensionFactoryTest.java
@@ -52,7 +52,6 @@ public class SingletonExtensionFactoryTest {
     @Test
     @SuppressWarnings("unchecked")
     public void createNewEachTimeFromDifferentClassLoaders() throws Exception {
-
         ExtensionFactory extensionFactory = new SingletonExtensionFactory();
 
         // Get classpath locations
@@ -70,11 +69,9 @@ public class SingletonExtensionFactoryTest {
 
         // assert that instances not same
         assertNotSame(instanceOne, instanceTwo);
-
     }
 
     private URL[] getClasspathReferences() throws MalformedURLException {
-
         String classpathProperty = System.getProperty("java.class.path");
 
         String[] classpaths = classpathProperty.split(":");

--- a/pf4j/src/test/java/org/pf4j/SingletonExtensionFactoryTest.java
+++ b/pf4j/src/test/java/org/pf4j/SingletonExtensionFactoryTest.java
@@ -19,11 +19,17 @@ import org.junit.jupiter.api.Test;
 import org.pf4j.plugin.FailTestExtension;
 import org.pf4j.plugin.TestExtension;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * @author Decebal Suiu
+ * @author Ajith Kumar
  */
 public class SingletonExtensionFactoryTest {
 
@@ -41,6 +47,43 @@ public class SingletonExtensionFactoryTest {
         Object extensionOne = extensionFactory.create(TestExtension.class);
         Object extensionTwo = extensionFactory.create(TestExtension.class);
         assertNotSame(extensionOne, extensionTwo);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void createNewEachTimeFromDifferentClassLoaders() throws Exception {
+
+        ExtensionFactory extensionFactory = new SingletonExtensionFactory();
+
+        // Get classpath locations
+        URL[] classpathReferences = getClasspathReferences();
+
+        // Create different classloaders for the classpath references and load classes respectively
+        ClassLoader klassLoaderOne = new URLClassLoader(classpathReferences, null);
+        Class klassOne = klassLoaderOne.loadClass(TestExtension.class.getName());
+        ClassLoader klassLoaderTwo = new URLClassLoader(classpathReferences, null);
+        Class klassTwo = klassLoaderTwo.loadClass(TestExtension.class.getName());
+
+        // create instances
+        Object instanceOne = extensionFactory.create(klassOne);
+        Object instanceTwo = extensionFactory.create(klassTwo);
+
+        // assert that instances not same
+        assertNotSame(instanceOne, instanceTwo);
+
+    }
+
+    private URL[] getClasspathReferences() throws MalformedURLException {
+
+        String classpathProperty = System.getProperty("java.class.path");
+
+        String[] classpaths = classpathProperty.split(":");
+        URL[] uris = new URL[classpaths.length];
+
+        for (int index = 0; index < classpaths.length; index++) {
+            uris[index] = new File(classpaths[index]).toURI().toURL();
+        }
+        return uris;
     }
 
 }


### PR DESCRIPTION
### What 
Bucketed cache in `SingletonExtensionFactory` grouped by `ClassLoaders`

### Why
`SingletonExtensionFactory` caches extensions based on class names alone. When two extensions with same class name from two different plugins(essentially two different `ClassLoaders`) are loaded, only one of them gets instantiated and also gets served twice. This might functionally be incorrect since two extension from two different plugins should be treated different even when they share the same name.

### Quickstart 
[quickstart link](https://github.com/ajithalbus/pf4j/tree/singleton-issue-starter/singleton)
Here an additional plugin for `Greeting` called `hello-plugin-japanese`(which greets with "ohayō" which loosely translates to  "hello" in Japanese) is added along with existing `hello-plugin`. The `HelloPlugin` class exists in both `hello-plugin-japanese` and `hello-plugin` in the same package. When the plugins are loaded with `SingletonExtensionFactory`, both the plugins are been loaded successfully but `pluginManager.getExtensions(Greeting.class)` returns duplicate instances of `HelloGreeting` originating from one of the plugin only. This results in the application greeting in Japanese(or English) twice.

```
Found 4 extensions for extension point 'com.livewire.Greeting'
>>> Whazzup
>>> Welcome
>>> ohayō
>>> ohayō
```