### PR TITLE
Support multiple plugin root directories

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -123,7 +123,16 @@ public abstract class AbstractPluginManager implements PluginManager {
      * @param pluginsRoots the roots to search for plugins
      */
     public AbstractPluginManager(Path... pluginsRoots) {
-        this.pluginsRoots.addAll(Arrays.asList(pluginsRoots));
+        this(Arrays.asList(pluginsRoots));
+    }
+
+    /**
+     * Constructs {@code AbstractPluginManager} with the given plugins roots.
+     *
+     * @param pluginsRoots the roots to search for plugins
+     */
+    public AbstractPluginManager(List<Path> pluginsRoots) {
+        this.pluginsRoots.addAll(pluginsRoots);
 
         initialize();
     }

--- a/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
@@ -41,8 +41,8 @@ public class DefaultPluginManager extends AbstractPluginManager {
         super();
     }
 
-    public DefaultPluginManager(Path pluginsRoot) {
-        super(pluginsRoot);
+    public DefaultPluginManager(Path... pluginsRoots) {
+        super(pluginsRoots);
     }
 
     @Override
@@ -73,7 +73,11 @@ public class DefaultPluginManager extends AbstractPluginManager {
     @Override
     protected PluginStatusProvider createPluginStatusProvider() {
         String configDir = System.getProperty(PLUGINS_DIR_CONFIG_PROPERTY_NAME);
-        Path configPath = configDir != null ? Paths.get(configDir) : getPluginsRoot();
+        Path configPath = configDir != null
+            ? Paths.get(configDir)
+            : getPluginsRoots().stream()
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("No pluginsRoot configured"));
 
         return new DefaultPluginStatusProvider(configPath);
     }
@@ -81,9 +85,9 @@ public class DefaultPluginManager extends AbstractPluginManager {
     @Override
     protected PluginRepository createPluginRepository() {
         return new CompoundPluginRepository()
-            .add(new DevelopmentPluginRepository(getPluginsRoot()), this::isDevelopment)
-            .add(new JarPluginRepository(getPluginsRoot()), this::isNotDevelopment)
-            .add(new DefaultPluginRepository(getPluginsRoot()), this::isNotDevelopment);
+            .add(new DevelopmentPluginRepository(getPluginsRoots()), this::isDevelopment)
+            .add(new JarPluginRepository(getPluginsRoots()), this::isNotDevelopment)
+            .add(new DefaultPluginRepository(getPluginsRoots()), this::isNotDevelopment);
     }
 
     @Override

--- a/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * Default implementation of the {@link PluginManager} interface.
@@ -42,6 +43,10 @@ public class DefaultPluginManager extends AbstractPluginManager {
     }
 
     public DefaultPluginManager(Path... pluginsRoots) {
+        super(pluginsRoots);
+    }
+
+    public DefaultPluginManager(List<Path> pluginsRoots) {
         super(pluginsRoots);
     }
 

--- a/pf4j/src/main/java/org/pf4j/DevelopmentPluginRepository.java
+++ b/pf4j/src/main/java/org/pf4j/DevelopmentPluginRepository.java
@@ -24,6 +24,8 @@ import org.pf4j.util.OrFileFilter;
 
 import java.io.FileFilter;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Decebal Suiu
@@ -33,8 +35,12 @@ public class DevelopmentPluginRepository extends BasePluginRepository {
     public static final String MAVEN_BUILD_DIR = "target";
     public static final String GRADLE_BUILD_DIR = "build";
 
-    public DevelopmentPluginRepository(Path pluginsRoot) {
-        super(pluginsRoot);
+    public DevelopmentPluginRepository(Path... pluginsRoots) {
+        this(Arrays.asList(pluginsRoots));
+    }
+
+    public DevelopmentPluginRepository(List<Path> pluginsRoots) {
+        super(pluginsRoots);
 
         AndFileFilter pluginsFilter = new AndFileFilter(new DirectoryFileFilter());
         pluginsFilter.addFileFilter(new NotFileFilter(createHiddenPluginFilter()));

--- a/pf4j/src/main/java/org/pf4j/JarPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/JarPluginManager.java
@@ -30,8 +30,8 @@ public class JarPluginManager extends DefaultPluginManager {
         super();
     }
 
-    public JarPluginManager(Path pluginsRoot) {
-        super(pluginsRoot);
+    public JarPluginManager(Path... pluginsRoots) {
+        super(pluginsRoots);
     }
 
     @Override
@@ -49,8 +49,8 @@ public class JarPluginManager extends DefaultPluginManager {
     @Override
     protected PluginRepository createPluginRepository() {
         return new CompoundPluginRepository()
-            .add(new DevelopmentPluginRepository(getPluginsRoot()), this::isDevelopment)
-            .add(new JarPluginRepository(getPluginsRoot()), this::isNotDevelopment);
+            .add(new DevelopmentPluginRepository(getPluginsRoots()), this::isDevelopment)
+            .add(new JarPluginRepository(getPluginsRoots()), this::isNotDevelopment);
     }
 
 }

--- a/pf4j/src/main/java/org/pf4j/JarPluginRepository.java
+++ b/pf4j/src/main/java/org/pf4j/JarPluginRepository.java
@@ -18,14 +18,20 @@ package org.pf4j;
 import org.pf4j.util.JarFileFilter;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Decebal Suiu
  */
 public class JarPluginRepository extends BasePluginRepository {
 
-    public JarPluginRepository(Path pluginsRoot) {
-        super(pluginsRoot, new JarFileFilter());
+    public JarPluginRepository(Path... pluginsRoots) {
+        this(Arrays.asList(pluginsRoots));
+    }
+
+    public JarPluginRepository(List<Path> pluginsRoots) {
+        super(pluginsRoots, new JarFileFilter());
     }
 
 }

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -205,11 +205,21 @@ public interface PluginManager {
     String getSystemVersion();
 
     /**
-     * Gets the path of the folder where plugins are installed.
+     * Gets the first path of the folders where plugins are installed.
+     *
+     * @deprecated Use {@link #getPluginsRoots()} instead to get all paths where plugins are could be installed.
      *
      * @return Path of plugins root
      */
+    @Deprecated
     Path getPluginsRoot();
+
+    /**
+     * Gets the a read-only list of all paths of the folders where plugins are installed.
+     *
+     * @return Paths of plugins roots
+     */
+    List<Path> getPluginsRoots();
 
     VersionManager getVersionManager();
 

--- a/pf4j/src/main/java/org/pf4j/ZipPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/ZipPluginManager.java
@@ -42,8 +42,8 @@ public class ZipPluginManager extends DefaultPluginManager {
     @Override
     protected PluginRepository createPluginRepository() {
         return new CompoundPluginRepository()
-            .add(new DevelopmentPluginRepository(getPluginsRoot()), this::isDevelopment)
-            .add(new DefaultPluginRepository(getPluginsRoot()), this::isNotDevelopment);
+            .add(new DevelopmentPluginRepository(getPluginsRoots()), this::isDevelopment)
+            .add(new DefaultPluginRepository(getPluginsRoots()), this::isNotDevelopment);
     }
 
 }

--- a/pf4j/src/test/java/org/pf4j/LoadPluginsFromMultipleRootsTest.java
+++ b/pf4j/src/test/java/org/pf4j/LoadPluginsFromMultipleRootsTest.java
@@ -15,11 +15,13 @@
  */
 package org.pf4j;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.pf4j.plugin.PluginZip;
+import org.pf4j.util.FileUtils;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -30,14 +32,20 @@ public class LoadPluginsFromMultipleRootsTest {
 
     private DefaultPluginManager pluginManager;
 
-    @TempDir
     Path pluginsPath1;
-    @TempDir
     Path pluginsPath2;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
+        pluginsPath1 = Files.createTempDirectory("junit-pf4j-");
+        pluginsPath2 = Files.createTempDirectory("junit-pf4j-");
         pluginManager = new DefaultPluginManager(pluginsPath1, pluginsPath2);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        FileUtils.delete(pluginsPath1);
+        FileUtils.delete(pluginsPath2);
     }
 
     @Test

--- a/pf4j/src/test/java/org/pf4j/LoadPluginsFromMultipleRootsTest.java
+++ b/pf4j/src/test/java/org/pf4j/LoadPluginsFromMultipleRootsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pf4j.plugin.PluginZip;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LoadPluginsFromMultipleRootsTest {
+
+    private DefaultPluginManager pluginManager;
+
+    @TempDir
+    Path pluginsPath1;
+    @TempDir
+    Path pluginsPath2;
+
+    @BeforeEach
+    public void setUp() {
+        pluginManager = new DefaultPluginManager(pluginsPath1, pluginsPath2);
+    }
+
+    @Test
+    public void load() throws Exception {
+        PluginZip pluginZip1 = new PluginZip.Builder(pluginsPath1.resolve("my-plugin-1.2.3.zip"), "myPlugin")
+            .pluginVersion("1.2.3")
+            .build();
+
+        PluginZip pluginZip2 = new PluginZip.Builder(pluginsPath2.resolve("my-other-plugin-4.5.6.zip"), "myOtherPlugin")
+            .pluginVersion("4.5.6")
+            .build();
+
+        assertTrue(Files.exists(pluginZip1.path()));
+        assertEquals(0, pluginManager.getPlugins().size());
+
+        pluginManager.loadPlugins();
+
+        assertTrue(Files.exists(pluginZip1.path()));
+        assertTrue(Files.exists(pluginZip1.unzippedPath()));
+        assertTrue(Files.exists(pluginZip2.path()));
+        assertTrue(Files.exists(pluginZip2.unzippedPath()));
+        assertEquals(2, pluginManager.getPlugins().size());
+        assertEquals(pluginZip1.pluginId(), pluginManager.idForPath(pluginZip1.unzippedPath()));
+        assertEquals(pluginZip2.pluginId(), pluginManager.idForPath(pluginZip2.unzippedPath()));
+    }
+
+}

--- a/pf4j/src/test/java/org/pf4j/LoadPluginsTest.java
+++ b/pf4j/src/test/java/org/pf4j/LoadPluginsTest.java
@@ -23,6 +23,7 @@ import org.pf4j.plugin.PluginZip;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -198,6 +199,11 @@ public class LoadPluginsTest {
     @Test
     public void getRoot() {
         assertEquals(pluginsPath, pluginManager.getPluginsRoot());
+    }
+
+    @Test
+    public void getRoots() {
+        assertEquals(Collections.singletonList(pluginsPath), pluginManager.getPluginsRoots());
     }
 
     @Test


### PR DESCRIPTION
* all constructors now support a varargs argument instead of a single Path
* property 'pf4j.pluginsDir' now supports a comma-separated list
* default directory for enabled / disabled files is the first plugin root
* PluginManager#getPluginsRoot() returns the first plugin root

Fixes #403

I tried to  keep the changes API-compatible. If binary compatibility is necessary, we could re-add the old One-Argument-Constructors.