### PR TITLE
Enable finding plugins in subdirectories of pluginsRoot

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -650,7 +650,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         return (version != null) ? version : "0.0.0";
     }
 
-    protected abstract PluginRepository createPluginRepository();
+    protected abstract PluginRepository createPluginRepository(PluginDescriptorFinder pluginDescriptorFinder);
 
     protected abstract PluginFactory createPluginFactory();
 
@@ -691,10 +691,10 @@ public abstract class AbstractPluginManager implements PluginManager {
             pluginsRoot = createPluginsRoot();
         }
 
-        pluginRepository = createPluginRepository();
+        pluginDescriptorFinder = createPluginDescriptorFinder();
+        pluginRepository = createPluginRepository(pluginDescriptorFinder);
         pluginFactory = createPluginFactory();
         extensionFactory = createExtensionFactory();
-        pluginDescriptorFinder = createPluginDescriptorFinder();
         extensionFinder = createExtensionFinder();
         pluginStatusProvider = createPluginStatusProvider();
         pluginLoader = createPluginLoader();

--- a/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
@@ -79,11 +79,11 @@ public class DefaultPluginManager extends AbstractPluginManager {
     }
 
     @Override
-    protected PluginRepository createPluginRepository() {
+    protected PluginRepository createPluginRepository(PluginDescriptorFinder pluginDescriptorFinder) {
         return new CompoundPluginRepository()
             .add(new DevelopmentPluginRepository(getPluginsRoot()), this::isDevelopment)
             .add(new JarPluginRepository(getPluginsRoot()), this::isNotDevelopment)
-            .add(new DefaultPluginRepository(getPluginsRoot()), this::isNotDevelopment);
+            .add(new DefaultPluginRepository(getPluginsRoot(), pluginDescriptorFinder), this::isNotDevelopment);
     }
 
     @Override

--- a/pf4j/src/main/java/org/pf4j/JarPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/JarPluginManager.java
@@ -47,7 +47,7 @@ public class JarPluginManager extends DefaultPluginManager {
     }
 
     @Override
-    protected PluginRepository createPluginRepository() {
+    protected PluginRepository createPluginRepository(PluginDescriptorFinder pluginDescriptorFinder) {
         return new CompoundPluginRepository()
             .add(new DevelopmentPluginRepository(getPluginsRoot()), this::isDevelopment)
             .add(new JarPluginRepository(getPluginsRoot()), this::isNotDevelopment);

--- a/pf4j/src/main/java/org/pf4j/ZipPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/ZipPluginManager.java
@@ -40,10 +40,10 @@ public class ZipPluginManager extends DefaultPluginManager {
     }
 
     @Override
-    protected PluginRepository createPluginRepository() {
+    protected PluginRepository createPluginRepository(PluginDescriptorFinder pluginDescriptorFinder) {
         return new CompoundPluginRepository()
             .add(new DevelopmentPluginRepository(getPluginsRoot()), this::isDevelopment)
-            .add(new DefaultPluginRepository(getPluginsRoot()), this::isNotDevelopment);
+            .add(new DefaultPluginRepository(getPluginsRoot(), pluginDescriptorFinder), this::isNotDevelopment);
     }
 
 }


### PR DESCRIPTION
Alternative approach addressing #403

DefaultPluginRepository scans for plugins in subfolders when a PluginDescriptorFinder is provided, so that it can decide if a subfolder is a plugin or just a directory possibly containing plugins or further subfolders.
To this end the AbstractPluginManager has been changed to initialize the finder first to be able to provide it to the PluginRepository creation.
There is some programming-by-exception when using the finder to decide if a directory is a plugin, but I wanted to do the exact same things as when creating the PluginDescriptor to make sure the check is really consistent with the creation.