### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>8</maven.compiler.release>
 
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.8.0-beta4</slf4j.version>
         <log4j.version>2.13.1</log4j.version>
         <asm.version>7.1</asm.version>
 


### PR DESCRIPTION
org.slf4j.ext.EventData in the slf4j-ext module in QOS.CH SLF4J before 1.8.0-beta2 allows remote attackers to bypass intended access restrictions via crafted data.
update the version of slf4j