### PR TITLE
Externalize some useful classes from testing

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -73,7 +73,7 @@
                         </goals>
                         <configuration>
                             <includes>
-                                <inculde>org/pf4j/plugin/*</inculde>
+                                <inculde>org/pf4j/test/*</inculde>
                             </includes>
                         </configuration>
                     </execution>

--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -66,6 +66,18 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <inculde>org/pf4j/plugin/*</inculde>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
@@ -113,8 +113,8 @@ public class AbstractExtensionFinderTest {
                 Map<String, Set<String>> entries = new LinkedHashMap<>();
 
                 Set<String> bucket = new HashSet<>();
-                bucket.add("org.pf4j.plugin.TestExtension");
-                bucket.add("org.pf4j.plugin.FailTestExtension");
+                bucket.add("org.pf4j.test.TestExtension");
+                bucket.add("org.pf4j.test.FailTestExtension");
                 entries.put(null, bucket);
 
                 return entries;
@@ -138,11 +138,11 @@ public class AbstractExtensionFinderTest {
                 Map<String, Set<String>> entries = new LinkedHashMap<>();
 
                 Set<String> bucket = new HashSet<>();
-                bucket.add("org.pf4j.plugin.TestExtension");
-                bucket.add("org.pf4j.plugin.FailTestExtension");
+                bucket.add("org.pf4j.test.TestExtension");
+                bucket.add("org.pf4j.test.FailTestExtension");
                 entries.put("plugin1", bucket);
                 bucket = new HashSet<>();
-                bucket.add("org.pf4j.plugin.TestExtension");
+                bucket.add("org.pf4j.test.TestExtension");
                 entries.put("plugin2", bucket);
 
                 return entries;

--- a/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
@@ -22,8 +22,8 @@ import java.util.Comparator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.FailTestPlugin;
-import org.pf4j.plugin.TestExtensionPoint;
+import org.pf4j.test.FailTestPlugin;
+import org.pf4j.test.TestExtensionPoint;
 
 import javax.tools.JavaFileObject;
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
@@ -16,8 +16,8 @@
 package org.pf4j;
 
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.TestExtension;
-import org.pf4j.plugin.TestExtensionPoint;
+import org.pf4j.test.TestExtension;
+import org.pf4j.test.TestExtensionPoint;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/pf4j/src/test/java/org/pf4j/CompoundPluginDescriptorFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/CompoundPluginDescriptorFinderTest.java
@@ -17,9 +17,9 @@ package org.pf4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginJar;
-import org.pf4j.plugin.PluginZip;
-import org.pf4j.plugin.TestPlugin;
+import org.pf4j.test.PluginJar;
+import org.pf4j.test.PluginZip;
+import org.pf4j.test.TestPlugin;
 
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/DefaultExtensionFactoryTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultExtensionFactoryTest.java
@@ -18,8 +18,8 @@ package org.pf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.FailTestExtension;
-import org.pf4j.plugin.TestExtension;
+import org.pf4j.test.FailTestExtension;
+import org.pf4j.test.TestExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginFactoryTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginFactoryTest.java
@@ -16,9 +16,9 @@
 package org.pf4j;
 
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.AnotherFailTestPlugin;
-import org.pf4j.plugin.FailTestPlugin;
-import org.pf4j.plugin.TestPlugin;
+import org.pf4j.test.AnotherFailTestPlugin;
+import org.pf4j.test.FailTestPlugin;
+import org.pf4j.test.TestPlugin;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginJar;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginJar;
+import org.pf4j.test.PluginZip;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginRepositoryTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginRepositoryTest.java
@@ -18,7 +18,7 @@ package org.pf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginZip;
 import org.pf4j.util.FileUtils;
 
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/JarPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/JarPluginManagerTest.java
@@ -19,10 +19,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginJar;
-import org.pf4j.plugin.TestExtension;
-import org.pf4j.plugin.TestExtensionPoint;
-import org.pf4j.plugin.TestPlugin;
+import org.pf4j.test.PluginJar;
+import org.pf4j.test.TestExtension;
+import org.pf4j.test.TestExtensionPoint;
+import org.pf4j.test.TestPlugin;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/pf4j/src/test/java/org/pf4j/LegacyExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/LegacyExtensionFinderTest.java
@@ -18,9 +18,9 @@ package org.pf4j;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginJar;
-import org.pf4j.plugin.TestExtension;
-import org.pf4j.plugin.TestPlugin;
+import org.pf4j.test.PluginJar;
+import org.pf4j.test.TestExtension;
+import org.pf4j.test.TestPlugin;
 
 import java.nio.file.Path;
 import java.util.Map;

--- a/pf4j/src/test/java/org/pf4j/LoadPluginsFromMultipleRootsTest.java
+++ b/pf4j/src/test/java/org/pf4j/LoadPluginsFromMultipleRootsTest.java
@@ -18,7 +18,7 @@ package org.pf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginZip;
 import org.pf4j.util.FileUtils;
 
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/LoadPluginsTest.java
+++ b/pf4j/src/test/java/org/pf4j/LoadPluginsTest.java
@@ -18,7 +18,7 @@ package org.pf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginZip;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/pf4j/src/test/java/org/pf4j/ManifestPluginDescriptorFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/ManifestPluginDescriptorFinderTest.java
@@ -18,7 +18,7 @@ package org.pf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginJar;
+import org.pf4j.test.PluginJar;
 
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginZip;
 import org.pf4j.util.FileUtils;
 
 import java.io.File;
@@ -49,7 +49,7 @@ public class PluginClassLoaderTest {
 
     private PluginClassLoader parentLastPluginClassLoader;
     private PluginClassLoader parentFirstPluginClassLoader;
-    
+
     private PluginClassLoader parentLastPluginDependencyClassLoader;
     private PluginClassLoader parentFirstPluginDependencyClassLoader;
 
@@ -95,7 +95,7 @@ public class PluginClassLoaderTest {
         pluginDependencyDescriptor.setProvider("Me");
         pluginDependencyDescriptor.setRequires("5.0.0");
 
-        
+
         Path pluginDependencyPath = pluginsPath.resolve(pluginDependencyDescriptor.getPluginId() + "-" + pluginDependencyDescriptor.getVersion() + ".zip");
         PluginZip pluginDependencyZip = new PluginZip.Builder(pluginDependencyPath, pluginDependencyDescriptor.getPluginId())
                 .pluginVersion(pluginDependencyDescriptor.getVersion())
@@ -110,11 +110,11 @@ public class PluginClassLoaderTest {
 
         parentLastPluginDependencyClassLoader = new PluginClassLoader(pluginManager, pluginDependencyDescriptor, PluginClassLoaderTest.class.getClassLoader());
         parentFirstPluginDependencyClassLoader = new PluginClassLoader(pluginManagerParentFirst, pluginDependencyDescriptor, PluginClassLoaderTest.class.getClassLoader(), true);
-        
+
         pluginManager.addClassLoader(pluginDependencyDescriptor.getPluginId(), parentLastPluginDependencyClassLoader);
         pluginManagerParentFirst.addClassLoader(pluginDependencyDescriptor.getPluginId(), parentFirstPluginDependencyClassLoader);
-        
-        
+
+
         for (String classesDirectory : pluginDependencyClasspath.getClassesDirectories()) {
             File classesDirectoryFile = pluginDependencyZip.unzippedPath().resolve(classesDirectory).toFile();
             parentLastPluginDependencyClassLoader.addFile(classesDirectoryFile);
@@ -129,7 +129,7 @@ public class PluginClassLoaderTest {
             	parentFirstPluginDependencyClassLoader.addFile(jar);
             }
         }
-        
+
         pluginDescriptor = new DefaultPluginDescriptor();
         pluginDescriptor.setPluginId("myPlugin");
         pluginDescriptor.setPluginVersion("1.2.3");
@@ -155,7 +155,7 @@ public class PluginClassLoaderTest {
 
         pluginManager.addClassLoader(pluginDescriptor.getPluginId(), parentLastPluginClassLoader);
         pluginManagerParentFirst.addClassLoader(pluginDescriptor.getPluginId(), parentFirstPluginClassLoader);
-        
+
         for (String classesDirectory : pluginClasspath.getClassesDirectories()) {
             File classesDirectoryFile = pluginZip.unzippedPath().resolve(classesDirectory).toFile();
             parentLastPluginClassLoader.addFile(classesDirectoryFile);
@@ -196,7 +196,7 @@ public class PluginClassLoaderTest {
         URL resource = parentLastPluginClassLoader.getResource("META-INF/file-only-in-parent");
         assertFirstLine("parent", resource);
     }
-    
+
     @Test
     void parentFirstGetResourceExistsInParent() throws IOException, URISyntaxException {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-only-in-parent");
@@ -214,7 +214,7 @@ public class PluginClassLoaderTest {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/plugin-file");
         assertFirstLine("plugin", resource);
     }
-    
+
     @Test
     void parentLastGetResourceExistsOnlyInDependnecy() throws IOException, URISyntaxException {
         URL resource = parentLastPluginClassLoader.getResource("META-INF/dependency-file");
@@ -238,13 +238,13 @@ public class PluginClassLoaderTest {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-in-both-parent-and-plugin");
         assertFirstLine("parent", resource);
     }
-    
+
     @Test
     void parentLastGetResourceExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
         URL resource = parentLastPluginClassLoader.getResource("META-INF/file-in-both-parent-and-dependency-and-plugin");
         assertFirstLine("plugin", resource);
     }
-    
+
     @Test
     void parentFirstGetResourceExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
         URL resource = parentFirstPluginClassLoader.getResource("META-INF/file-in-both-parent-and-dependency-and-plugin");
@@ -284,7 +284,7 @@ public class PluginClassLoaderTest {
         Enumeration<URL> resources = parentFirstPluginClassLoader.getResources("META-INF/dependency-file");
         assertNumberOfResourcesAndFirstLineOfFirstElement(1, "dependency", resources);
     }
-    
+
     @Test
     void parentLastGetResourcesExistsOnlyInPlugin() throws IOException, URISyntaxException {
         Enumeration<URL> resources = parentLastPluginClassLoader.getResources("META-INF/plugin-file");
@@ -308,7 +308,7 @@ public class PluginClassLoaderTest {
         Enumeration<URL> resources = parentFirstPluginClassLoader.getResources("META-INF/file-in-both-parent-and-plugin");
         assertNumberOfResourcesAndFirstLineOfFirstElement(2, "parent", resources);
     }
-    
+
     @Test
     void parentLastGetResourcesExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
         Enumeration<URL> resources = parentLastPluginClassLoader.getResources("META-INF/file-in-both-parent-and-dependency-and-plugin");
@@ -333,9 +333,9 @@ public class PluginClassLoaderTest {
         URL firstResource = list.get(0);
         assertEquals(expectedFirstLine, Files.readAllLines(Paths.get(firstResource.toURI())).get(0));
     }
-    
+
     class TestPluginManager extends DefaultPluginManager {
-    	
+
     	public TestPluginManager(Path pluginsPath) {
 			super(pluginsPath);
 		}

--- a/pf4j/src/test/java/org/pf4j/PropertiesPluginDescriptorFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PropertiesPluginDescriptorFinderTest.java
@@ -18,8 +18,8 @@ package org.pf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginZip;
-import org.pf4j.plugin.TestPlugin;
+import org.pf4j.test.PluginZip;
+import org.pf4j.test.TestPlugin;
 
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/SingletonExtensionFactoryTest.java
+++ b/pf4j/src/test/java/org/pf4j/SingletonExtensionFactoryTest.java
@@ -16,8 +16,8 @@
 package org.pf4j;
 
 import org.junit.jupiter.api.Test;
-import org.pf4j.plugin.FailTestExtension;
-import org.pf4j.plugin.TestExtension;
+import org.pf4j.test.FailTestExtension;
+import org.pf4j.test.TestExtension;
 
 import java.io.File;
 import java.net.MalformedURLException;

--- a/pf4j/src/test/java/org/pf4j/test/AnotherFailTestPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/AnotherFailTestPlugin.java
@@ -18,6 +18,9 @@ package org.pf4j.test;
 import org.pf4j.Plugin;
 
 /**
+ * A wrong {@link org.pf4j.Plugin}.
+ * It's wrong because it doesn't contain a constructor with one parameter ({@link org.pf4j.PluginWrapper} as parameter type).
+ *
  * @author Mario Franco
  */
 public class AnotherFailTestPlugin extends Plugin {

--- a/pf4j/src/test/java/org/pf4j/test/AnotherFailTestPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/AnotherFailTestPlugin.java
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
+
+import org.pf4j.Plugin;
 
 /**
  * @author Mario Franco
  */
-public class FailTestPlugin {
+public class AnotherFailTestPlugin extends Plugin {
+
+    public AnotherFailTestPlugin() {
+        super(null);
+    }
 
 }

--- a/pf4j/src/test/java/org/pf4j/test/ClassDataProvider.java
+++ b/pf4j/src/test/java/org/pf4j/test/ClassDataProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
 /**
  * Defines the interface for classes that know to supply class data for a class name.

--- a/pf4j/src/test/java/org/pf4j/test/DefaultClassDataProvider.java
+++ b/pf4j/src/test/java/org/pf4j/test/DefaultClassDataProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/pf4j/src/test/java/org/pf4j/test/FailTestExtension.java
+++ b/pf4j/src/test/java/org/pf4j/test/FailTestExtension.java
@@ -13,15 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
-import org.pf4j.ExtensionPoint;
+import org.pf4j.Extension;
 
 /**
  * @author Mario Franco
  */
-public interface TestExtensionPoint extends ExtensionPoint {
+@Extension
+public class FailTestExtension implements TestExtensionPoint {
 
-    String saySomething();
+    public FailTestExtension(String name) {
+    }
+
+    @Override
+    public String saySomething() {
+        return "I am a fail test extension";
+    }
 
 }

--- a/pf4j/src/test/java/org/pf4j/test/FailTestExtension.java
+++ b/pf4j/src/test/java/org/pf4j/test/FailTestExtension.java
@@ -18,6 +18,9 @@ package org.pf4j.test;
 import org.pf4j.Extension;
 
 /**
+ * A wrong {@link org.pf4j.Extension}.
+ * It's wrong because it doesn't contain a constructor with empty parameters (or only the default constructor).
+ *
  * @author Mario Franco
  */
 @Extension

--- a/pf4j/src/test/java/org/pf4j/test/FailTestPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/FailTestPlugin.java
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
-
-import org.pf4j.Plugin;
-import org.pf4j.PluginWrapper;
+package org.pf4j.test;
 
 /**
  * @author Mario Franco
  */
-public class TestPlugin extends Plugin {
-
-    public TestPlugin(PluginWrapper wrapper) {
-        super(wrapper);
-    }
+public class FailTestPlugin {
 
 }

--- a/pf4j/src/test/java/org/pf4j/test/FailTestPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/FailTestPlugin.java
@@ -16,6 +16,9 @@
 package org.pf4j.test;
 
 /**
+ * A wrong {@link org.pf4j.Plugin}.
+ * It's wrong because it doesn't extends {@link org.pf4j.Plugin}.
+ *
  * @author Mario Franco
  */
 public class FailTestPlugin {

--- a/pf4j/src/test/java/org/pf4j/test/PluginJar.java
+++ b/pf4j/src/test/java/org/pf4j/test/PluginJar.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
 import org.pf4j.ManifestPluginDescriptorFinder;
 

--- a/pf4j/src/test/java/org/pf4j/test/PluginZip.java
+++ b/pf4j/src/test/java/org/pf4j/test/PluginZip.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
 import org.pf4j.PropertiesPluginDescriptorFinder;
 

--- a/pf4j/src/test/java/org/pf4j/test/TestExtension.java
+++ b/pf4j/src/test/java/org/pf4j/test/TestExtension.java
@@ -18,6 +18,8 @@ package org.pf4j.test;
 import org.pf4j.Extension;
 
 /**
+ * A simple {@link Extension}. It implements {@link TestExtensionPoint}.
+ *
  * @author Mario Franco
  */
 @Extension

--- a/pf4j/src/test/java/org/pf4j/test/TestExtension.java
+++ b/pf4j/src/test/java/org/pf4j/test/TestExtension.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
 import org.pf4j.Extension;
 

--- a/pf4j/src/test/java/org/pf4j/test/TestExtensionPoint.java
+++ b/pf4j/src/test/java/org/pf4j/test/TestExtensionPoint.java
@@ -13,22 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
-import org.pf4j.Extension;
+import org.pf4j.ExtensionPoint;
 
 /**
  * @author Mario Franco
  */
-@Extension
-public class FailTestExtension implements TestExtensionPoint {
+public interface TestExtensionPoint extends ExtensionPoint {
 
-    public FailTestExtension(String name) {
-    }
-
-    @Override
-    public String saySomething() {
-        return "I am a fail test extension";
-    }
+    String saySomething();
 
 }

--- a/pf4j/src/test/java/org/pf4j/test/TestExtensionPoint.java
+++ b/pf4j/src/test/java/org/pf4j/test/TestExtensionPoint.java
@@ -18,6 +18,8 @@ package org.pf4j.test;
 import org.pf4j.ExtensionPoint;
 
 /**
+ * A simple {@link ExtensionPoint} that contains one method ({@link #saySomething()}).
+ *
  * @author Mario Franco
  */
 public interface TestExtensionPoint extends ExtensionPoint {

--- a/pf4j/src/test/java/org/pf4j/test/TestPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/TestPlugin.java
@@ -19,6 +19,11 @@ import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
 
 /**
+ * A simple {@link Plugin}.
+ *
+ * In real applications you don't need to create a plugin like this if you are not interested in lifecycle events.
+ * {@codes PF4J} will automatically create a plugin similar to this (empty / dummy) if no class plugin is specified.
+ *
  * @author Mario Franco
  */
 public class TestPlugin extends Plugin {

--- a/pf4j/src/test/java/org/pf4j/test/TestPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/TestPlugin.java
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pf4j.plugin;
+package org.pf4j.test;
 
 import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
 
 /**
  * @author Mario Franco
  */
-public class AnotherFailTestPlugin extends Plugin {
+public class TestPlugin extends Plugin {
 
-    public AnotherFailTestPlugin() {
-        super(null);
+    public TestPlugin(PluginWrapper wrapper) {
+        super(wrapper);
     }
 
 }

--- a/pf4j/src/test/java/org/pf4j/test/package-info.java
+++ b/pf4j/src/test/java/org/pf4j/test/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Classes used to test different aspects of PF4J (plugins, extensions points, extensions).
+ *
+ * @author Decebal Suiu
+ */
+package org.pf4j.test;

--- a/pf4j/src/test/java/org/pf4j/util/FileUtilsTest.java
+++ b/pf4j/src/test/java/org/pf4j/util/FileUtilsTest.java
@@ -17,7 +17,7 @@ package org.pf4j.util;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginZip;
 
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
The idea of this PR is to allow other PF4J-based applications to use classes from `test/src`. 
We have some interesting concepts like `PluginJar`, `PluginZip`, `ClassDataProvider` (and more will probably be added in the future).

For more details see https://github.com/pf4j/pf4j/issues/414.

It's very simple to use these classes in your test suite.
Just add the snippet below to your POM file and that it's all:
```xml
<dependency>
    <groupId>org.pf4j</groupId>
    <artifactId>pf4j</artifactId>
    <version>${pf4j.version}</version>
    <!--            
    <classifier>tests</classifier>
    -->
    <type>test-jar</type>
    <scope>test</scope>
</dependency>
```