### PR TITLE
Fix for #394

### DIFF
--- a/pf4j/src/main/java/org/pf4j/DependencyResolver.java
+++ b/pf4j/src/main/java/org/pf4j/DependencyResolver.java
@@ -88,7 +88,7 @@ public class DependencyResolver {
             String pluginId = plugin.getPluginId();
             String existingVersion = plugin.getVersion();
 
-            List<String> dependents = new ArrayList<>(getDependents(pluginId));
+            List<String> dependents = getDependents(pluginId);
             while (!dependents.isEmpty()) {
                 String dependentId = dependents.remove(0);
                 PluginDescriptor dependent = pluginByIds.get(dependentId);
@@ -107,22 +107,22 @@ public class DependencyResolver {
      * Retrieves the plugins ids that the given plugin id directly depends on.
      *
      * @param pluginId the unique plugin identifier, specified in its metadata
-     * @return
+     * @return an immutable list of dependencies (new list for each call)
      */
     public List<String> getDependencies(String pluginId) {
         checkResolved();
-        return dependenciesGraph.getNeighbors(pluginId);
+        return new ArrayList<>(dependenciesGraph.getNeighbors(pluginId));
     }
 
     /**
      * Retrieves the plugins ids that the given content is a direct dependency of.
      *
      * @param pluginId the unique plugin identifier, specified in its metadata
-     * @return
+     * @return an immutable list of dependents (new list for each call)
      */
     public List<String> getDependents(String pluginId) {
         checkResolved();
-        return dependentsGraph.getNeighbors(pluginId);
+        return new ArrayList<>(dependentsGraph.getNeighbors(pluginId));
     }
 
     /**

--- a/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
@@ -15,7 +15,6 @@
  */
 package org.pf4j;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
@@ -18,7 +18,7 @@ package org.pf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.pf4j.plugin.PluginZip;
+import org.pf4j.test.PluginZip;
 
 import java.nio.file.Path;
 

--- a/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
@@ -16,7 +16,12 @@
 package org.pf4j;
 
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pf4j.plugin.PluginZip;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,6 +31,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Mario Franco
  */
 public class PluginDependencyTest {
+
+    private DefaultPluginManager pluginManager;
+
+    @TempDir
+    Path pluginsPath;
+
+    @BeforeEach
+    public void setUp() {
+        pluginManager = new DefaultPluginManager(pluginsPath);
+    }
 
     /**
      * Test of getPluginId method, of class PluginDependency.
@@ -75,6 +90,35 @@ public class PluginDependencyTest {
         assertEquals("1.0", instance.getPluginVersionSupport());
         assertTrue(instance.isOptional());
         assertEquals("PluginDependency [pluginId=test, pluginVersionSupport=1.0, optional=true]", instance.toString());
+    }
+
+    @Test
+    public void dependentStop() throws Exception {
+        // B depends on A
+        PluginZip pluginA = new PluginZip.Builder(pluginsPath.resolve("A-plugin-1.2.3.zip"), "plugin.a")
+            .pluginVersion("1.2.3").build();
+
+        PluginZip pluginB = new PluginZip.Builder(pluginsPath.resolve("B-plugin-1.2.3.zip"), "plugin.b")
+            .pluginDependencies("plugin.a")
+            .pluginVersion("1.2.3").build();
+
+        pluginManager.loadPlugins();
+        assertEquals(2, pluginManager.getPlugins().size());
+
+        pluginManager.startPlugins();
+        assertEquals(2, pluginManager.getStartedPlugins().size());
+
+        // stop A, both A and B should be stopped
+        pluginManager.stopPlugin("plugin.a");
+        assertEquals(0, pluginManager.getStartedPlugins().size());
+
+        // start all again
+        pluginManager.startPlugins();
+        assertEquals(2, pluginManager.getStartedPlugins().size());
+
+        // dependent info should be kept. #394
+        pluginManager.stopPlugin("plugin.a");
+        assertEquals(0, pluginManager.getStartedPlugins().size());
     }
 
 }

--- a/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginDependencyTest.java
@@ -120,4 +120,30 @@ public class PluginDependencyTest {
         assertEquals(0, pluginManager.getStartedPlugins().size());
     }
 
+    @Test
+    public void dependentUnload() throws Exception {
+        // B depends on A
+        PluginZip pluginA = new PluginZip.Builder(pluginsPath.resolve("A-plugin-1.2.3.zip"), "plugin.a")
+            .pluginVersion("1.2.3").build();
+
+        PluginZip pluginB = new PluginZip.Builder(pluginsPath.resolve("B-plugin-1.2.3.zip"), "plugin.b")
+            .pluginDependencies("plugin.a")
+            .pluginVersion("1.2.3").build();
+
+        pluginManager.loadPlugins();
+        assertEquals(2, pluginManager.getPlugins().size());
+
+        pluginManager.startPlugins();
+        assertEquals(2, pluginManager.getStartedPlugins().size());
+
+        // stop A, both A and B should be stopped
+        pluginManager.stopPlugin("plugin.a");
+        assertEquals(0, pluginManager.getStartedPlugins().size());
+
+        // unload A, both A and B should be unloaded
+        pluginManager.unloadPlugin("plugin.a");
+        assertEquals(0, pluginManager.getResolvedPlugins().size());
+        assertEquals(0, pluginManager.getPlugins().size());
+    }
+
 }

--- a/pf4j/src/test/java/org/pf4j/plugin/PluginZip.java
+++ b/pf4j/src/test/java/org/pf4j/plugin/PluginZip.java
@@ -39,12 +39,14 @@ public class PluginZip {
     private final String pluginId;
     private final String pluginClass;
     private final String pluginVersion;
+    private final String pluginDependencies;
 
     protected PluginZip(Builder builder) {
         this.path = builder.path;
         this.pluginId = builder.pluginId;
         this.pluginClass = builder.pluginClass;
         this.pluginVersion = builder.pluginVersion;
+        this.pluginDependencies = builder.pluginDependencies;
     }
 
     public Path path() {
@@ -67,6 +69,8 @@ public class PluginZip {
         return pluginVersion;
     }
 
+    public String pluginDependencies() { return pluginDependencies; }
+
     public Path unzippedPath() {
         Path path = path();
         String fileName = path.getFileName().toString();
@@ -88,6 +92,7 @@ public class PluginZip {
 
         private String pluginClass;
         private String pluginVersion;
+        private String pluginDependencies;
         private Map<String, String> properties = new LinkedHashMap<>();
         private Map<Path, byte[]> files = new LinkedHashMap<>();
 
@@ -104,6 +109,12 @@ public class PluginZip {
 
         public Builder pluginVersion(String pluginVersion) {
             this.pluginVersion = pluginVersion;
+
+            return this;
+        }
+
+        public Builder pluginDependencies(String pluginDependencies) {
+            this.pluginDependencies = pluginDependencies;
 
             return this;
         }
@@ -162,6 +173,9 @@ public class PluginZip {
             Map<String, String> map = new LinkedHashMap<>();
             map.put(PropertiesPluginDescriptorFinder.PLUGIN_ID, pluginId);
             map.put(PropertiesPluginDescriptorFinder.PLUGIN_VERSION, pluginVersion);
+            if (pluginDependencies != null) {
+                map.put(PropertiesPluginDescriptorFinder.PLUGIN_DEPENDENCIES, pluginDependencies);
+            }
             if (pluginClass != null) {
                 map.put(PropertiesPluginDescriptorFinder.PLUGIN_CLASS, pluginClass);
             }


### PR DESCRIPTION
It's based on https://github.com/pf4j/pf4j/pull/416. Thanks @hank-cp!

The test passed. See below a fragment of log for `PluginDependencyTest#dependentStop` (the test that replicates the issue):
```
2021-01-08 22:24:23,798 DEBUG org.pf4j.DependencyResolver - Graph: 
   plugin.a -> []
   plugin.b -> [plugin.a]
2021-01-08 22:24:23,799 DEBUG org.pf4j.DependencyResolver - Plugins order: [plugin.a, plugin.b]
2021-01-08 22:24:23,805 INFO org.pf4j.AbstractPluginManager - Plugin 'plugin.a@1.2.3' resolved
2021-01-08 22:24:23,805 INFO org.pf4j.AbstractPluginManager - Plugin 'plugin.b@1.2.3' resolved
2021-01-08 22:24:23,807 INFO org.pf4j.AbstractPluginManager - Start plugin 'plugin.a@1.2.3'
2021-01-08 22:24:23,807 DEBUG org.pf4j.DefaultPluginFactory - Create instance for plugin 'org.pf4j.Plugin'
2021-01-08 22:24:23,807 INFO org.pf4j.AbstractPluginManager - Start plugin 'plugin.b@1.2.3'
2021-01-08 22:24:23,807 DEBUG org.pf4j.DefaultPluginFactory - Create instance for plugin 'org.pf4j.Plugin'
2021-01-08 22:24:23,808 INFO org.pf4j.AbstractPluginManager - Stop plugin 'plugin.b@1.2.3'
2021-01-08 22:24:23,808 INFO org.pf4j.AbstractPluginManager - Stop plugin 'plugin.a@1.2.3'
2021-01-08 22:24:23,808 INFO org.pf4j.AbstractPluginManager - Start plugin 'plugin.a@1.2.3'
2021-01-08 22:24:23,808 INFO org.pf4j.AbstractPluginManager - Start plugin 'plugin.b@1.2.3'
2021-01-08 22:24:23,808 INFO org.pf4j.AbstractPluginManager - Stop plugin 'plugin.b@1.2.3'
2021-01-08 22:24:23,808 INFO org.pf4j.AbstractPluginManager - Stop plugin 'plugin.a@1.2.3'
```