### PR TITLE
add validation befor plugin can be started

### DIFF
--- a/pf4j/src/main/java/org/pf4j/Plugin.java
+++ b/pf4j/src/main/java/org/pf4j/Plugin.java
@@ -55,6 +55,16 @@ public class Plugin {
     public final PluginWrapper getWrapper() {
         return wrapper;
     }
+    
+    /**
+     * This  method is called by the application when the plugin is loaded and when enable() is called for this plugin.
+     * When this method returns false it cannot be enabled. This can be used to disable a plugin on certain OS, ...
+     * See {@link PluginManager#isPluginValid(PluginWrapper)}.
+     * @return
+     */
+    public boolean validate() {
+        return true;
+    }
 
     /**
      * This method is called by the application when the plugin is started.

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
@@ -19,8 +19,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.pf4j.test.InvalidPlugin;
 import org.pf4j.test.PluginJar;
 import org.pf4j.test.PluginZip;
+import org.pf4j.test.TestExtension;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -56,6 +58,7 @@ public class DefaultPluginManagerTest {
         pluginDescriptor.setRequires("5.0.0");
 
         pluginWrapper = new PluginWrapper(pluginManager, pluginDescriptor, Files.createTempDirectory("test"), getClass().getClassLoader());
+        pluginWrapper.setPluginFactory(new DefaultPluginFactory());
     }
 
     @AfterEach
@@ -118,6 +121,15 @@ public class DefaultPluginManagerTest {
 
         pluginManager.setSystemVersion("6.0.0");
         assertFalse(pluginManager.isPluginValid(pluginWrapper));
+    }
+
+    @Test
+    public void isPluginValidCustomPluginValidation() throws IOException {
+        new PluginJar.Builder(pluginsPath.resolve("test-plugin.jar"), "invalid-test-plugin")
+                .pluginClass(InvalidPlugin.class.getName()).pluginVersion("1.2.3").extension(TestExtension.class.getName()).build();
+        pluginManager = new JarPluginManager(pluginsPath);
+        pluginManager.loadPlugins();
+        assertFalse(pluginManager.isPluginValid(pluginManager.getPlugin("invalid-test-plugin")));
     }
 
     @Test

--- a/pf4j/src/test/java/org/pf4j/test/InvalidPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/InvalidPlugin.java
@@ -1,0 +1,24 @@
+package org.pf4j.test;
+
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+
+/**
+ * A simple {@link Plugin} which simulates being on a wrong operating system
+ *
+ * @author Wolfram Haussig
+ */
+public class InvalidPlugin extends Plugin {
+
+    public InvalidPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    /**
+     * In reality, one would check requirements like the correct OS, certain installed applications, ... here
+     */
+    @Override
+    public boolean validate() {
+        return false;
+    }
+}


### PR DESCRIPTION
closes #444

- add validate() method to plugin class
- call validate() in isPluginValid() to run the custom plugin validation
- add test for isPluginValid()