### PR TITLE
do not rely on version from Manifest

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -20,6 +20,18 @@
 
     <build>
         <plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>filter-src</id>
+						<goals>
+							<goal>filter-sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pf4j/src/main/java-templates/org/pf4j/Pf4jInfo.java
+++ b/pf4j/src/main/java-templates/org/pf4j/Pf4jInfo.java
@@ -16,10 +16,11 @@
 package org.pf4j;
 
 /**
- * class provides access to the current Pf4j version which might otherwise not be possible(e.g. in Uber-Jars where the Manifest wass overridden)
+ * This class provides access to the current Pf4j version which might otherwise not be possible:
+ * e.g. in Uber-Jars where the Manifest was merged and the Pf4j info was overridden
  * @author Wolfram Haussig
  */
-public class Pf4jVersion {
+public class Pf4jInfo {
     /**
      * the current Pf4j version
      */

--- a/pf4j/src/main/java-templates/org/pf4j/Pf4jVersion.java
+++ b/pf4j/src/main/java-templates/org/pf4j/Pf4jVersion.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j;
+
+/**
+ * class provides access to the current Pf4j version which might otherwise not be possible(e.g. in Uber-Jars where the Manifest wass overridden)
+ * @author Wolfram Haussig
+ */
+public class Pf4jVersion {
+    /**
+     * the current Pf4j version
+     */
+    public static final String VERSION = "${project.version}";
+}

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -660,7 +660,7 @@ public abstract class AbstractPluginManager implements PluginManager {
     }
 
     public String getVersion() {
-        return Pf4jVersion.VERSION;
+        return Pf4jInfo.VERSION;
     }
 
     protected abstract PluginRepository createPluginRepository();

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -660,17 +660,7 @@ public abstract class AbstractPluginManager implements PluginManager {
     }
 
     public String getVersion() {
-        String version = null;
-
-        Package pf4jPackage = PluginManager.class.getPackage();
-        if (pf4jPackage != null) {
-            version = pf4jPackage.getImplementationVersion();
-            if (version == null) {
-                version = pf4jPackage.getSpecificationVersion();
-            }
-        }
-
-        return (version != null) ? version : "0.0.0";
+        return Pf4jVersion.VERSION;
     }
 
     protected abstract PluginRepository createPluginRepository();

--- a/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
@@ -46,6 +46,7 @@ public class AbstractPluginManagerTest {
         List<TestExtensionPoint> extensions = pluginManager.getExtensions(TestExtensionPoint.class);
         assertEquals(1, extensions.size());
     }
+    
     @Test
     public void getVersion() {
         AbstractPluginManager pluginManager = mock(AbstractPluginManager.class, CALLS_REAL_METHODS);

--- a/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,6 +45,11 @@ public class AbstractPluginManagerTest {
         pluginManager.extensionFinder = extensionFinder;
         List<TestExtensionPoint> extensions = pluginManager.getExtensions(TestExtensionPoint.class);
         assertEquals(1, extensions.size());
+    }
+    @Test
+    public void getVersion() {
+        AbstractPluginManager pluginManager = mock(AbstractPluginManager.class, CALLS_REAL_METHODS);
+        assertNotEquals("0.0.0", pluginManager.getVersion());
     }
 
 }


### PR DESCRIPTION
solves #390

- added generated class Pf4jVersion to contain the current version
- added templating-maven-plugin to add project version into Pf4jVersion
- added UnitTest for version