### PR TITLE
Only call `stopPlugin` during unload if the plugin is started

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -280,6 +280,9 @@ public abstract class AbstractPluginManager implements PluginManager {
                     dependents.addAll(0, dependencyResolver.getDependents(dependent));
                 }
             }
+
+            checkPluginId(pluginId);
+
             PluginWrapper pluginWrapper = getPlugin(pluginId);
             PluginState pluginState;
             try {
@@ -466,8 +469,10 @@ public abstract class AbstractPluginManager implements PluginManager {
             return PluginState.STOPPED;
         }
 
-        // test for disabled plugin
-        if (PluginState.DISABLED == pluginState) {
+        if (PluginState.DISABLED == pluginState ||
+            PluginState.CREATED == pluginState ||
+            PluginState.RESOLVED == pluginState) {
+
             // do nothing
             return pluginState;
         }

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
@@ -28,6 +28,8 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -190,4 +192,20 @@ public class DefaultPluginManagerTest {
         assertFalse(pluginJar.file().exists());
     }
 
+    @Test
+    public void loadedPluginWithMissingDependencyCanBeUnloaded() throws IOException {
+        PluginZip pluginZip = new PluginZip.Builder(pluginsPath.resolve("my-plugin-1.1.1.zip"), "myPlugin")
+            .pluginVersion("1.1.1")
+            .pluginDependencies("myBasePlugin")
+            .build();
+
+        pluginManager.loadPlugins();
+        pluginManager.startPlugins();
+
+        PluginWrapper myPlugin = pluginManager.getPlugin(pluginZip.pluginId());
+        assertNotNull(myPlugin);
+        assertNotEquals(PluginState.STARTED, myPlugin.getPluginState());
+
+        assertTrue(pluginManager.unloadPlugin(pluginZip.pluginId()));
+    }
 }


### PR DESCRIPTION
Related to #459.