### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 
         <sonar.organization>pf4j</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <build>
@@ -77,6 +78,9 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.1</version>
+                    <configuration>
+                    	<disableXmlReport>${closeTestReports}</disableXmlReport>
+                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
