### PR TITLE
Update Log4j version to 2.17.0

### DIFF
--- a/maven-archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/maven-archetypes/quickstart/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
 
         <pf4j.version>{{project.version}}</pf4j.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.release>8</maven.compiler.release>
 
         <slf4j.version>1.7.30</slf4j.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <asm.version>9.1</asm.version>
 
         <junit.version>5.4.0</junit.version>


### PR DESCRIPTION
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105