### PR TITLE
Update README url

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ PF4J is very customizable and comes with a lot of goodies. Please read the docum
 
 Documentation
 ---------------
-Documentation is available on [pf4j.org](http://www.pf4j.org)
+Documentation is available on [pf4j.org](http://pf4j.org)
 
 Demo
 ---------------


### PR DESCRIPTION
Update README url to avoid SSL_ERROR_BAD_CERT_DOMAIN error when connecting to side

Currently, when you click on the link in the README, you get this very nice page (firefox):

![image](https://user-images.githubusercontent.com/46940694/150221916-5c9d54d2-d695-47ee-a1a9-534f09af8c81.png)

This change fixes that by updating `http://www.pf4j.org` -> `http://pf4j.org`