### PR TITLE
Update Gradle demo to pass plugin dependencies into Manifest

### DIFF
--- a/demo_gradle/plugins/build.gradle
+++ b/demo_gradle/plugins/build.gradle
@@ -4,7 +4,8 @@ subprojects {
       attributes 'Plugin-Class': "${pluginClass}",
           'Plugin-Id': "${pluginId}",
           'Plugin-Version': "${archiveVersion}",
-          'Plugin-Provider': "${pluginProvider}"
+          'Plugin-Provider': "${pluginProvider}",
+          'Plugin-Dependencies': "${pluginDependencies}"
     }
   }
 


### PR DESCRIPTION
The Gradle demo plugins have `pluginDependencies` in their properties file which aren't written into the manifest, though.

After basing my own code on that example, I didn't properly review it, which resulted in [some confusion](https://github.com/pf4j/pf4j/issues/497#issuecomment-1451119488) the other day :grimacing: 

So maybe adding it here will prevent from someone else making the same copy&paste-mistake :sweat_smile: 