### PR TITLE
Add security checks to prevent directory traversal when decompressing…

### DIFF
--- a/pf4j/src/main/java/org/pf4j/util/FileUtils.java
+++ b/pf4j/src/main/java/org/pf4j/util/FileUtils.java
@@ -185,11 +185,6 @@ public final class FileUtils {
         String directoryName = fileName.substring(0, fileName.lastIndexOf("."));
         Path pluginDirectory = filePath.resolveSibling(directoryName);
 
-        // Check whether directory traversal risks exist in the path
-        if (!isInvalidPath(pluginDirectory)) {
-            throw new SecurityException("Invalid destination directory");
-        }
-
         if (!Files.exists(pluginDirectory) || pluginZipDate.compareTo(Files.getLastModifiedTime(pluginDirectory)) > 0) {
             // expand '.zip' file
             Unzip unzip = new Unzip();
@@ -202,13 +197,6 @@ public final class FileUtils {
         return pluginDirectory;
     }
 
-    /**
-     * Use regular expressions to check whether the path contains a path traversal attempt
-     */
-    private static boolean isInvalidPath(Path path) {
-        String pathStr = path.toString();
-        return pathStr.matches(".*\\.\\.(\\\\|/).*");
-    }
 
     /**
      * Return true only if path is a zip file.

--- a/pf4j/src/main/java/org/pf4j/util/FileUtils.java
+++ b/pf4j/src/main/java/org/pf4j/util/FileUtils.java
@@ -185,6 +185,11 @@ public final class FileUtils {
         String directoryName = fileName.substring(0, fileName.lastIndexOf("."));
         Path pluginDirectory = filePath.resolveSibling(directoryName);
 
+        // Check whether directory traversal risks exist in the path
+        if (!isInvalidPath(pluginDirectory)) {
+            throw new SecurityException("Invalid destination directory");
+        }
+
         if (!Files.exists(pluginDirectory) || pluginZipDate.compareTo(Files.getLastModifiedTime(pluginDirectory)) > 0) {
             // expand '.zip' file
             Unzip unzip = new Unzip();
@@ -195,6 +200,14 @@ public final class FileUtils {
         }
 
         return pluginDirectory;
+    }
+
+    /**
+     * Use regular expressions to check whether the path contains a path traversal attempt
+     */
+    private static boolean isInvalidPath(Path path) {
+        String pathStr = path.toString();
+        return pathStr.matches(".*\\.\\.(\\\\|/).*");
     }
 
     /**

--- a/pf4j/src/main/java/org/pf4j/util/Unzip.java
+++ b/pf4j/src/main/java/org/pf4j/util/Unzip.java
@@ -20,7 +20,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
 
 import org.slf4j.Logger;
@@ -80,6 +83,11 @@ public class Unzip {
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                 File file = new File(destination, zipEntry.getName());
 
+                // add check
+                if (zipEntry.getName().indexOf("..") != -1 && !file.getCanonicalPath().startsWith(destination.getCanonicalPath())) {
+                    throw new ZipException("The file "+zipEntry.getName()+" is trying to leave the target output directory of "+destination+". Ignoring this file.");
+                }
+
                 // create intermediary directories - sometimes zip don't add them
                 File dir = new File(file.getParent());
 
@@ -99,6 +107,8 @@ public class Unzip {
             }
         }
     }
+
+
 
     private static void mkdirsOrThrow(File dir) throws IOException {
         if (!dir.exists() && !dir.mkdirs()) {

--- a/pf4j/src/test/java/org/pf4j/LoadPluginsTest.java
+++ b/pf4j/src/test/java/org/pf4j/LoadPluginsTest.java
@@ -20,10 +20,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.pf4j.test.PluginZip;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -36,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.pf4j.util.FileUtils.expandIfZip;
 
 public class LoadPluginsTest {
 

--- a/pf4j/src/test/java/org/pf4j/util/FileUtilsTest.java
+++ b/pf4j/src/test/java/org/pf4j/util/FileUtilsTest.java
@@ -24,9 +24,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.pf4j.util.FileUtils.expandIfZip;
 
 public class FileUtilsTest {
 
@@ -95,4 +98,48 @@ public class FileUtilsTest {
         }
         return file;
     }
+
+    /**
+     * Using the zipslip vulnerability, create a zip file.
+     *
+     * Save the created zip file in the D:/code/pf4j directory, if you do not have this path on your computer D drive, create it
+     * @throws Exception
+     */
+    @Test
+    public void creatFile() throws Exception {
+
+        String maliciousFileName = "../../../../../../../malicious.sh";
+
+        // Build a malicious ZIP file
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream("malicious.zip"))) {
+            ZipEntry entry = new ZipEntry(maliciousFileName);
+            zipOutputStream.putNextEntry(entry);
+            zipOutputStream.write("Malicious content".getBytes());
+            zipOutputStream.closeEntry();
+        }
+    }
+
+    /**
+     * Try to extract malicious.zip to the root directory of drive D on your computer.
+     * @throws Exception
+     */
+    @Test
+    public void loadFile() throws Exception {
+        // Save the created zip file in the D:/code/pf4j directory, if you do not have this path on your computer D drive, create it
+        String maliciousZipPath = "D:\\code\\pf4j\\malicious.zip";
+
+        // Unzip file
+        expandIfZip(Paths.get(maliciousZipPath));
+        //loadPluginFromPath(Paths.get(maliciousZipPath));
+
+        // Check whether the specified file exists in the directory
+        File  file = new File("D:\\malicious.sh");
+        if (file.exists()) {
+            System.out.println("file exists: Directory traversal successful!");
+        } else {
+            System.out.println("file does not exist!");
+        }
+    }
+
+
 }


### PR DESCRIPTION
## This is a PR submission for #536

To verify that there is a directory traversal risk when unzipping the zip file, I test in FileUtilsTest.java.

1.Using the zipslip vulnerability, create a zip file.Save the created zip file in the D:/code/pf4j directory, if you do not have this path on your computer D drive, create it.
![image](https://github.com/pf4j/pf4j/assets/85676107/8e35bd86-1d8a-4c6c-be3d-b23deee66e77)

2. Next, call expandIfZip or loadPluginFromPath method to extract the zip file to the root directory of disk D of the computer.
![image](https://github.com/pf4j/pf4j/assets/85676107/a5470dfd-d64d-48f8-bfba-30481f401f8a)

3.To prevent path crossing problems caused by unsafe input, I recommend adding checks to the extract() method.
![image](https://github.com/pf4j/pf4j/assets/85676107/71c4b951-6f29-49b2-a611-15864a28b1ce)



After adding the check, an exception is thrown when there is a malicious file name
![image](https://github.com/pf4j/pf4j/assets/85676107/3bcf61e5-6574-4cba-84df-3810a25a1876)


Sorry, commits/c1b03c92c03cc42ef7d197d962acd785bbea60dd is wrong, commits/ed9392069fe14c6c30d9f876710e5ad40f7ea8c1 provide repair plan is correct.
