### PR TITLE
Write empty extensions descriptor even if no extensions are found

### DIFF
--- a/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java
+++ b/pf4j/src/main/java/org/pf4j/processor/ExtensionAnnotationProcessor.java
@@ -130,10 +130,10 @@ public class ExtensionAnnotationProcessor extends AbstractProcessor {
             }
         }
 
-        // write extensions
-        if (extensions.size() > 0) {
-            storage.write(extensions);
-        }
+        // Even an empty extensions descriptor is semantically correct and should be
+        // written to prevent classloaders from falling back to extension descriptor
+        // resources from dependencies of the plugin being processed.
+        storage.write(extensions);
 
         return false;
     }


### PR DESCRIPTION
Closes #550 

I tried this only with the legacy mechanism. Not 100% sure whether it works with JDK9 module mechanism, too - but I see no reason that it shouldn't.