### PR TITLE
Upgrade Java SemVer to 0.10.2

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>
             <artifactId>java-semver</artifactId>
-            <version>0.9.0</version>
+            <version>0.10.2</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/pf4j/src/main/java/module-info.java
+++ b/pf4j/src/main/java/module-info.java
@@ -34,7 +34,7 @@ module org.pf4j {
     // The java-semver library currently does not provide a module.
     // Maybe we should send them a pull request, that at least they provide an
     // automatic module name in their MANIFEST file.
-    requires java.semver;
+    requires com.github.zafarkhaja.semver;
 
     // Maybe we should reconsider the package hierarchy, that only classes are
     // exported, which are required by 3rd party developers.


### PR DESCRIPTION
Recently, I have noticed that the project <https://github.com/zafarkhaja/jsemver> has become active again and they have releases some new versions. See <https://github.com/zafarkhaja/jsemver/releases> for more.

This PR upgrades the dependency to [0.10.2(latest)](https://github.com/zafarkhaja/jsemver/releases/tag/v0.10.2).