### PR TITLE
Fix the problem of unable doing sonar scanning in JDK 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,22 +13,18 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
+            - name: Set up JDK 17
+              uses: actions/setup-java@v4
               with:
-                  java-version: 11
+                  distribution: "temurin"
+                  java-version: 17
+                  cache: maven
             - name: Cache SonarCloud packages
               uses: actions/cache@v1
               with:
                   path: ~/.sonar/cache
                   key: ${{ runner.os }}-sonar
                   restore-keys: ${{ runner.os }}-sonar
-            - name: Cache Maven packages
-              uses: actions/cache@v1
-              with:
-                  path: ~/.m2
-                  key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-                  restore-keys: ${{ runner.os }}-m2
             - name: Build and analyze
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
I have noticed that there are too many failure actions as sonar refuses to scan in JDK 11, please refer to <https://github.com/pf4j/pf4j/actions/runs/7700538547/job/20984594068>.

```bash
Warning:  The version of Java (11.0.22) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31.371 s
[INFO] Finished at: 2024-01-25T04:16:40Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.10.0.2594:sonar (default-cli) on project pf4j: 
Error:  
Error:  The version of Java (11.0.22) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
Error:  As a temporary measure, you can set the property 'sonar.scanner.force-deprecated-java-version' to 'true' to continue using Java 11.0.22
Error:  This workaround will only be effective until January 28, 2024. After this date, all scans using the deprecated Java 11 will fail.
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```

This PR changes build environment to JDK 17 and simplify Maven cache.

> <https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597/26>