### PR TITLE
Add strategy for handling the recovery of a plugin that could not be resolved

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -305,6 +306,7 @@ public abstract class AbstractPluginManager implements PluginManager {
 
             log.info("Unload plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
         } catch (Exception e) {
+            log.error("Cannot stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()), e);
             pluginState = PluginState.FAILED;
         }
 
@@ -1092,7 +1094,7 @@ public abstract class AbstractPluginManager implements PluginManager {
      *
      * @return the strategy
      */
-    protected ResolveRecoveryStrategy getResolveRecoveryStrategy() {
+    protected final ResolveRecoveryStrategy getResolveRecoveryStrategy() {
         return resolveRecoveryStrategy;
     }
 
@@ -1102,6 +1104,7 @@ public abstract class AbstractPluginManager implements PluginManager {
      * @param resolveRecoveryStrategy the strategy
      */
     protected void setResolveRecoveryStrategy(ResolveRecoveryStrategy resolveRecoveryStrategy) {
+        Objects.requireNonNull(resolveRecoveryStrategy, "resolveRecoveryStrategy cannot be null");
         this.resolveRecoveryStrategy = resolveRecoveryStrategy;
     }
 
@@ -1109,7 +1112,7 @@ public abstract class AbstractPluginManager implements PluginManager {
      * Strategy for handling the recovery of a plugin that could not be resolved
      * (loaded) due to a dependency problem.
      */
-    enum ResolveRecoveryStrategy {
+    public enum ResolveRecoveryStrategy {
 
         /**
          * Throw an exception when a resolve (load) failure occurs.

--- a/pf4j/src/main/java/org/pf4j/DependencyResolver.java
+++ b/pf4j/src/main/java/org/pf4j/DependencyResolver.java
@@ -218,6 +218,15 @@ public class DependencyResolver {
         }
 
         /**
+         * Returns true if there are dependencies required that were not found.
+         *
+         * @return true if there are dependencies required that were not found
+         */
+        public boolean hasNotFoundDependencies() {
+            return !notFoundDependencies.isEmpty();
+        }
+
+        /**
          * Returns a list with dependencies required that were not found.
          *
          * @return a list with dependencies required that were not found
@@ -227,12 +236,30 @@ public class DependencyResolver {
         }
 
         /**
+         * Returns true if there are dependencies with wrong version.
+         *
+         * @return true if there are dependencies with wrong version
+         */
+        public boolean hasWrongVersionDependencies() {
+            return !wrongVersionDependencies.isEmpty();
+        }
+
+        /**
          * Returns a list with dependencies with wrong version.
          *
          * @return a list with dependencies with wrong version
          */
         public List<WrongDependencyVersion> getWrongVersionDependencies() {
             return wrongVersionDependencies;
+        }
+
+        /**
+         * Returns true if the result is OK (no cyclic dependency, no not found dependencies, no wrong version dependencies).
+         *
+         * @return true if the result is OK
+         */
+        public boolean isOK() {
+            return !hasCyclicDependency() && !hasNotFoundDependencies() && !hasWrongVersionDependencies();
         }
 
         /**
@@ -333,7 +360,7 @@ public class DependencyResolver {
      */
     public static class DependenciesWrongVersionException extends PluginRuntimeException {
 
-        private List<WrongDependencyVersion> dependencies;
+        private final List<WrongDependencyVersion> dependencies;
 
         public DependenciesWrongVersionException(List<WrongDependencyVersion> dependencies) {
             super("Dependencies '{}' have wrong version", dependencies);

--- a/pf4j/src/main/java/org/pf4j/PluginNotFoundException.java
+++ b/pf4j/src/main/java/org/pf4j/PluginNotFoundException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j;
+
+/**
+ * Thrown when a plugin is not found.
+ *
+ * @author Decebal Suiu
+ */
+public class PluginNotFoundException extends PluginRuntimeException {
+
+    private final String pluginId;
+
+    public PluginNotFoundException(String pluginId) {
+        super("Plugin '{}' not found", pluginId);
+
+        this.pluginId = pluginId;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+}

--- a/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractPluginManagerTest.java
@@ -18,12 +18,10 @@ package org.pf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.pf4j.test.TestExtension;
 import org.pf4j.test.TestExtensionPoint;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -118,7 +116,7 @@ public class AbstractPluginManagerTest {
 
     @Test
     void checkNotExistedPluginId() {
-        assertThrows(IllegalArgumentException.class, () -> pluginManager.checkPluginId("plugin1"));
+        assertThrows(PluginNotFoundException.class, () -> pluginManager.checkPluginId("plugin1"));
     }
 
     private PluginWrapper createPluginWrapper(String pluginId) {
@@ -127,7 +125,7 @@ public class AbstractPluginManagerTest {
         pluginDescriptor.setPluginVersion("1.2.3");
 
         PluginWrapper pluginWrapper = new PluginWrapper(pluginManager, pluginDescriptor, Paths.get("plugin1"), getClass().getClassLoader());
-        Plugin plugin= mock(Plugin.class);
+        Plugin plugin = mock(Plugin.class);
         pluginWrapper.setPluginFactory(wrapper -> plugin);
 
         return pluginWrapper;


### PR DESCRIPTION
Strategy for handling the recovery of a plugin that could not be resolved (loaded) due to a dependency problem.
Possible values:

- THROW_EXCEPTION -> Throw an exception when a resolve (load) failure occurs
- IGNORE_PLUGIN_AND_CONTINUE -> Ignore the plugin with the resolve (load) failure and continue;
the plugin with problems will be removed/unloaded from the plugins list
