### PR TITLE
Fix maven warning about plugin version

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -23,6 +23,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>templating-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>filter-src</id>


### PR DESCRIPTION
Fixes this warning from Maven (using 3.6.3 locally):

```
Warning:  Some problems were encountered while building the effective model for org.pf4j:pf4j:jar:3.11.0-SNAPSHOT
Warning:  'build.plugins.plugin.version' for org.codehaus.mojo:templating-maven-plugin is missing. @ line 23, column 21
Warning:
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
```