### PR TITLE
Fix StackOverFlow error on Kotlin classes without @Extension

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -199,6 +199,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>2.0.21</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
@@ -358,7 +358,12 @@ public abstract class AbstractExtensionFinder implements ExtensionFinder, Plugin
         // search recursively through all annotations
         for (Annotation annotation : clazz.getAnnotations()) {
             Class<? extends Annotation> annotationClass = annotation.annotationType();
-            if (!annotationClass.getName().startsWith("java.lang.annotation")) {
+            if (!annotationClass.getName().startsWith("java.lang.annotation") && !annotationClass.getName().startsWith("kotlin")) {
+                // In case an annotation is annotated with itself,
+                // an example would be @Target, which is ignored by the check above
+                // however, other libraries might do similar things
+                if (annotationClass.equals(clazz)) continue;
+
                 Extension extensionAnnotation = findExtensionAnnotation(annotationClass);
                 if (extensionAnnotation != null) {
                     return extensionAnnotation;

--- a/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/AbstractExtensionFinderTest.java
@@ -15,6 +15,7 @@
  */
 package org.pf4j;
 
+import kotlin.sequences.Sequence;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -274,4 +275,11 @@ public class AbstractExtensionFinderTest {
         Assertions.assertNull(extension);
     }
 
+    // This is a regression test, as this caused an StackOverflowError with the previous implementation
+    @Test
+    public void runningOnNonExtensionKotlinClassDoesNotThrowException() {
+        Extension result = AbstractExtensionFinder.findExtensionAnnotation(Sequence.class);
+
+        Assertions.assertNull(result);
+    }
 }


### PR DESCRIPTION
Currently this method gets caught in a loop (target -> retention -> mustbedocumented -> target) if @Extension is not present

this fixes it