### PR TITLE
Fix verify error under Java 21

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -182,12 +182,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
             <version>0.21.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         <junit.version>5.4.0</junit.version>
         <hamcrest.version>2.1</hamcrest.version>
-        <mockito.version>5.2.0</mockito.version>
+        <mockito.version>5.14.2</mockito.version>
 
         <javadoc.disabled>false</javadoc.disabled>
         <deploy.disabled>false</deploy.disabled>


### PR DESCRIPTION
When I try to execute `./mvnw clean verify` to verify project under JDK 21, the following errors will be output:

```java
[ERROR] testFindFailType  Time elapsed: 0.045 s  <<< ERROR!
org.mockito.exceptions.base.MockitoException: 

Mockito cannot mock this class: class org.pf4j.PluginWrapper.

If you're not sure why you're getting this error, please open an issue on GitHub.


Java               : 21
JVM vendor name    : Eclipse Adoptium
JVM vendor version : 21.0.5+11-LTS
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 21.0.5+11-LTS
JVM info           : mixed mode, sharing
OS name            : Linux
OS version         : 6.11.8-300.fc41.x86_64


You are seeing this disclaimer because Mockito is configured to create inlined mocks.
You can learn about inline mocks and their limitations under item #39 of the Mockito class javadoc.

Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [class java.lang.Object, class org.pf4j.PluginWrapper]
        at org.pf4j.AbstractExtensionFinderTest.setUp(AbstractExtensionFinderTest.java:52)
Caused by: org.mockito.exceptions.base.MockitoException: Could not modify all classes [class java.lang.Object, class org.pf4j.PluginWrapper]
        at org.pf4j.AbstractExtensionFinderTest.setUp(AbstractExtensionFinderTest.java:52)
Caused by: java.lang.IllegalStateException: 

Byte Buddy could not instrument all classes within the mock's type hierarchy

This problem should never occur for javac-compiled classes. This problem has been observed for classes that are:
 - Compiled by older versions of scalac
 - Classes that are part of the Android distribution
        at org.pf4j.AbstractExtensionFinderTest.setUp(AbstractExtensionFinderTest.java:52)
Caused by: java.lang.IllegalArgumentException: Java 21 (65) is not supported by the current version of Byte Buddy which officially supports Java 20 (64) - update Byte Buddy or set net.bytebuddy.experimental as a VM property
        at org.pf4j.AbstractExtensionFinderTest.setUp(AbstractExtensionFinderTest.java:52)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   AbstractExtensionFinderTest.setUp:52 Mockito 
Mockito cannot mock this class: ...
```

Then, I found the Mockito 5.2.0 didn't support Java 21. For more details, please refer to <https://github.com/mockito/mockito/issues/3321>.

This PR upgrades to Mockito [5.14.2](https://github.com/mockito/mockito/releases/tag/v5.14.2), and no errors will come.

And I also tested under JDK 11, it works very well.

#### Why do I remove the dependency `mockito-inline`?

Please refer to <https://github.com/mockito/mockito/issues/3039>.