### PR TITLE
Exclude bin folder built by Eclipse or VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 .idea/
 *.iml
 demo-dist/
+bin/
+


### PR DESCRIPTION
This PR add `bin/` into `.gitignore` file to exclude bin folder built by Eclipse or VSCode. See the output of `git status`:

```bash
❯ git status
HEAD detached at upstream/master
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        demo/gradle/api/bin/
        demo/gradle/app/bin/
        demo/gradle/plugins/plugin1/bin/
        demo/gradle/plugins/plugin2/bin/
        demo/gradle/plugins/plugin3/bin/

nothing added to commit but untracked files present (use "git add" to track)
```