### PR TITLE
Fix static variables preventing classloader recycling

### DIFF
--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -43,8 +43,8 @@ public class PluginClassLoader extends URLClassLoader {
 
     private static final Logger log = LoggerFactory.getLogger(PluginClassLoader.class);
 
-    private static final String JAVA_PACKAGE_PREFIX = "java.";
-    private static final String PLUGIN_PACKAGE_PREFIX = "org.pf4j.";
+    private  final String JAVA_PACKAGE_PREFIX = "java.";
+    private  final String PLUGIN_PACKAGE_PREFIX = "org.pf4j.";
 
     private final PluginManager pluginManager;
     private final PluginDescriptor pluginDescriptor;


### PR DESCRIPTION
After reloading multiple times, I found that the class loader will not be recycled and there are no references anymore. According to jprofile analysis, the phenomenon is that there are static fields in the PluginClassLoader.

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/fdca1340-0c00-4dfd-8b6f-405d735687ed" />
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/a9ec16f7-de31-4b48-8488-4e960dd340dc" />
