### PR TITLE
Fix exception handling inconsistency in startPlugin()

### DIFF
--- a/pf4j/src/test/java/org/pf4j/test/FailingPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/FailingPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.test;
+
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+
+/**
+ * A {@link Plugin} that throws an exception when started.
+ * Used for testing exception handling in plugin lifecycle.
+ *
+ * @author Decebal Suiu
+ */
+public class FailingPlugin extends Plugin {
+
+    public FailingPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    @Override
+    public void start() {
+        throw new RuntimeException("Intentional failure for testing");
+    }
+
+}


### PR DESCRIPTION
Fixes #624

Problem:
The startPlugin() method did not handle exceptions during plugin startup, while startPlugins() properly caught exceptions and set the plugin state to FAILED. This created inconsistent behavior.

Solution:
Refactored exception handling logic into a private doStartPlugin() method that is now used by both startPlugin() and startPlugins(). This ensures consistent exception handling across both methods.

Changes:
- Extracted doStartPlugin() method with proper try-catch-finally
- Both methods now set plugin state to FAILED on exception
- Both methods now store the exception in failedException
- Both methods now fire state change events correctly
- Added comprehensive tests for exception scenarios