### PR TITLE
Validate dependency state on plugin start

### DIFF
--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -81,9 +81,14 @@ public interface PluginManager {
 
     /**
      * Start the specified plugin and its dependencies.
+     * <p>
+     * If the returned state is {@link PluginState#FAILED}, you can retrieve the failure reason
+     * by calling {@link PluginWrapper#getFailedException()} on the plugin wrapper.
      *
-     * @return the plugin state
+     * @param pluginId the unique plugin identifier, specified in its metadata
+     * @return the plugin state after the start operation
      * @throws PluginRuntimeException if something goes wrong
+     * @see PluginWrapper#getFailedException()
      */
     PluginState startPlugin(String pluginId);
 

--- a/pf4j/src/main/java/org/pf4j/PluginWrapper.java
+++ b/pf4j/src/main/java/org/pf4j/PluginWrapper.java
@@ -175,10 +175,14 @@ public class PluginWrapper {
     }
 
     /**
-     * Returns the exception with which the plugin fails to start.
-     * See @{link PluginStatus#FAILED}.
+     * Returns the exception that caused the plugin to fail.
+     * <p>
+     * When a plugin's state is {@link PluginState#FAILED}, this method returns the exception
+     * that caused the failure (e.g., exception during start, dependency failure, etc.).
+     * Returns {@code null} if the plugin has not failed or if no exception information is available.
      *
-     * @return the exception with which the plugin fails to start
+     * @return the exception that caused the plugin to fail, or {@code null} if not applicable
+     * @see PluginState#FAILED
      */
     public Throwable getFailedException() {
         return failedException;


### PR DESCRIPTION
Fixes #628

   ## Summary

   This PR adds validation of dependency state during plugin startup to prevent plugins from starting when their required dependencies have failed to start.

   ## Changes

   - Extract `startDependencies()` method with comprehensive JavaDoc documenting behavior for required vs optional dependencies
   - Validate dependency state after starting each dependency
   - Required dependencies that fail to start now prevent the dependent plugin from starting (plugin state set to FAILED)
   - Optional dependencies that fail to start log a warning but allow the dependent plugin to start (degraded mode)
   - Add tests for required dependency failures, optional dependency failures, and cascading failures

   ## Behavior

   **Required dependencies:**
   - If a required dependency fails to start, the dependent plugin will NOT start
   - Plugin state is set to FAILED with a clear error message
   - Prevents runtime errors by failing fast at startup

   **Optional dependencies:**
   - If not loaded, skipped (existing behavior)
   - If loaded but fails to start, logs a WARNING and allows dependent to start
   - Plugin is responsible for handling missing optional functionality gracefully

   ## Testing

   Added 3 new tests:
   - `shouldFailToStartPluginWhenRequiredDependencyFailsToStart` - verifies required dependency validation
   - `shouldStartPluginWhenOptionalDependencyFailsToStart` - verifies optional dependency handling
   - `shouldHandleCascadingDependencyFailures` - verifies cascading failure propagation

   All 26 tests pass.