### PR TITLE
Set failedException when plugin validation or stop fails (#630)

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -538,6 +538,9 @@ public abstract class AbstractPluginManager implements PluginManager {
                     firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
                 } catch (PluginRuntimeException e) {
                     log.error(e.getMessage(), e);
+                    pluginWrapper.setPluginState(PluginState.FAILED);
+                    pluginWrapper.setFailedException(e);
+                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
                 }
             } else {
                 // do nothing
@@ -647,6 +650,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         PluginWrapper pluginWrapper = getPlugin(pluginId);
         if (!isPluginValid(pluginWrapper)) {
             log.warn("Plugin '{}' can not be enabled", getPluginLabel(pluginWrapper.getDescriptor()));
+            pluginWrapper.setFailedException(new PluginRuntimeException("Plugin validation failed"));
             return false;
         }
 
@@ -997,6 +1001,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         if (!isPluginValid(pluginWrapper)) {
             log.warn("Plugin '{}' is invalid and it will be disabled", pluginPath);
             pluginWrapper.setPluginState(PluginState.DISABLED);
+            pluginWrapper.setFailedException(new PluginRuntimeException("Plugin validation failed"));
         }
 
         log.debug("Created wrapper '{}' for plugin '{}'", pluginWrapper, pluginPath);

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -320,6 +320,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         } catch (Exception e) {
             log.error("Cannot stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()), e);
             pluginState = PluginState.FAILED;
+            pluginWrapper.setFailedException(e);
         }
 
         // remove the plugin
@@ -359,8 +360,9 @@ public abstract class AbstractPluginManager implements PluginManager {
         PluginWrapper pluginWrapper = getPlugin(pluginId);
         // stop the plugin if it's started
         PluginState pluginState = stopPlugin(pluginId);
-        if (pluginState.isStarted()) {
+        if (pluginState.isFailed()) {
             log.error("Failed to stop plugin '{}' on delete", pluginId);
+            // failedException already set by doStopPlugin()
             return false;
         }
 
@@ -370,6 +372,9 @@ public abstract class AbstractPluginManager implements PluginManager {
 
         if (!unloadPlugin(pluginId)) {
             log.error("Failed to unload plugin '{}' on delete", pluginId);
+            if (pluginWrapper.getFailedException() == null) {
+                pluginWrapper.setFailedException(new PluginRuntimeException("Failed to unload plugin"));
+            }
             return false;
         }
 
@@ -529,19 +534,7 @@ public abstract class AbstractPluginManager implements PluginManager {
             PluginWrapper pluginWrapper = itr.next();
             PluginState pluginState = pluginWrapper.getPluginState();
             if (pluginState.isStarted()) {
-                try {
-                    log.info("Stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
-                    pluginWrapper.getPlugin().stop();
-                    pluginWrapper.setPluginState(PluginState.STOPPED);
-                    itr.remove();
-
-                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
-                } catch (PluginRuntimeException e) {
-                    log.error(e.getMessage(), e);
-                    pluginWrapper.setPluginState(PluginState.FAILED);
-                    pluginWrapper.setFailedException(e);
-                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
-                }
+                doStopPlugin(pluginWrapper);
             } else {
                 // do nothing
                 log.debug("Plugin '{}' is not started, nothing to stop", getPluginLabel(pluginWrapper.getDescriptor()));
@@ -583,15 +576,32 @@ public abstract class AbstractPluginManager implements PluginManager {
             }
         }
 
-        log.info("Stop plugin '{}'", getPluginLabel(pluginId));
         PluginWrapper pluginWrapper = getPlugin(pluginId);
-        pluginWrapper.getPlugin().stop();
-        pluginWrapper.setPluginState(PluginState.STOPPED);
-        getStartedPlugins().remove(pluginWrapper);
+        return doStopPlugin(pluginWrapper);
+    }
 
-        firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, PluginState.STARTED));
-
-        return PluginState.STOPPED;
+    /**
+     * Performs the actual plugin stop operation with proper exception handling.
+     * This method is used by both {@link #stopPlugin(String, boolean)} and {@link #stopPlugins()}.
+     *
+     * @param pluginWrapper the plugin wrapper to stop
+     * @return the plugin state after the stop operation
+     */
+    private PluginState doStopPlugin(PluginWrapper pluginWrapper) {
+        PluginState pluginState = pluginWrapper.getPluginState();
+        try {
+            log.info("Stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
+            pluginWrapper.getPlugin().stop();
+            pluginWrapper.setPluginState(PluginState.STOPPED);
+            getStartedPlugins().remove(pluginWrapper);
+        } catch (PluginRuntimeException e) {
+            log.error(e.getMessage(), e);
+            pluginWrapper.setPluginState(PluginState.FAILED);
+            pluginWrapper.setFailedException(e);
+        } finally {
+            firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
+        }
+        return pluginWrapper.getPluginState();
     }
 
     /**
@@ -627,8 +637,10 @@ public abstract class AbstractPluginManager implements PluginManager {
             log.debug("Already disabled plugin '{}'", getPluginLabel(pluginDescriptor));
             return true;
         } else if (pluginState.isStarted()) {
-            if (!stopPlugin(pluginId).isStopped()) {
+            PluginState result = stopPlugin(pluginId);
+            if (result.isFailed()) {
                 log.error("Failed to stop plugin '{}' on disable", getPluginLabel(pluginDescriptor));
+                // failedException already set by doStopPlugin()
                 return false;
             }
         }

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
@@ -722,4 +722,29 @@ class DefaultPluginManagerTest {
         assertTrue(plugin.getFailedException().getMessage().contains("stop"));
     }
 
+    @Test
+    void unloadPluginWithStopFailureSetsFailedException() throws IOException {
+        PluginZip pluginZip = new PluginZip.Builder(pluginsPath.resolve("failing-unload-plugin-1.0.0.zip"), "failingUnloadPlugin")
+            .pluginVersion("1.0.0")
+            .pluginClass("org.pf4j.test.FailingStopPlugin")
+            .build();
+
+        pluginManager.loadPlugins();
+        pluginManager.startPlugin("failingUnloadPlugin");
+
+        PluginWrapper plugin = pluginManager.getPlugin("failingUnloadPlugin");
+        assertEquals(PluginState.STARTED, plugin.getPluginState());
+
+        // Unload - stop will fail
+        boolean result = pluginManager.unloadPlugin("failingUnloadPlugin");
+
+        // unloadPlugin continues even if stop fails, so result is true
+        assertTrue(result);
+        // Plugin should be in UNLOADED state now (set after the exception)
+        assertEquals(PluginState.UNLOADED, plugin.getPluginState());
+        // But failedException should be set from the stop failure
+        assertNotNull(plugin.getFailedException());
+        assertTrue(plugin.getFailedException().getMessage().contains("stop"));
+    }
+
 }

--- a/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
+++ b/pf4j/src/test/java/org/pf4j/DefaultPluginManagerTest.java
@@ -680,4 +680,46 @@ class DefaultPluginManagerTest {
         assertTrue(plugin.getFailedException().getMessage().contains("validation failed"));
     }
 
+    @Test
+    void disablePluginWithStopFailureSetsFailedException() throws IOException {
+        PluginZip pluginZip = new PluginZip.Builder(pluginsPath.resolve("failing-disable-plugin-1.0.0.zip"), "failingDisablePlugin")
+            .pluginVersion("1.0.0")
+            .pluginClass("org.pf4j.test.FailingStopPlugin")
+            .build();
+
+        pluginManager.loadPlugins();
+        pluginManager.startPlugin("failingDisablePlugin");
+
+        PluginWrapper plugin = pluginManager.getPlugin("failingDisablePlugin");
+        assertEquals(PluginState.STARTED, plugin.getPluginState());
+
+        // Try to disable - stop will fail
+        boolean result = pluginManager.disablePlugin("failingDisablePlugin");
+
+        assertFalse(result);
+        assertNotNull(plugin.getFailedException());
+        assertTrue(plugin.getFailedException().getMessage().contains("stop"));
+    }
+
+    @Test
+    void deletePluginWithStopFailureSetsFailedException() throws IOException {
+        PluginZip pluginZip = new PluginZip.Builder(pluginsPath.resolve("failing-delete-plugin-1.0.0.zip"), "failingDeletePlugin")
+            .pluginVersion("1.0.0")
+            .pluginClass("org.pf4j.test.FailingStopPlugin")
+            .build();
+
+        pluginManager.loadPlugins();
+        pluginManager.startPlugin("failingDeletePlugin");
+
+        PluginWrapper plugin = pluginManager.getPlugin("failingDeletePlugin");
+        assertEquals(PluginState.STARTED, plugin.getPluginState());
+
+        // Try to delete - stop will fail
+        boolean result = pluginManager.deletePlugin("failingDeletePlugin");
+
+        assertFalse(result);
+        assertNotNull(plugin.getFailedException());
+        assertTrue(plugin.getFailedException().getMessage().contains("stop"));
+    }
+
 }

--- a/pf4j/src/test/java/org/pf4j/test/FailingStopPlugin.java
+++ b/pf4j/src/test/java/org/pf4j/test/FailingStopPlugin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.test;
+
+import org.pf4j.Plugin;
+import org.pf4j.PluginRuntimeException;
+import org.pf4j.PluginWrapper;
+
+/**
+ * A {@link Plugin} that throws an exception when stopped.
+ * Used for testing exception handling in plugin lifecycle.
+ *
+ * @author Decebal Suiu
+ */
+public class FailingStopPlugin extends Plugin {
+
+    public FailingStopPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    @Override
+    public void stop() {
+        throw new PluginRuntimeException("Intentional failure during stop for testing");
+    }
+
+}

--- a/pf4j/src/test/java/org/pf4j/test/PluginZip.java
+++ b/pf4j/src/test/java/org/pf4j/test/PluginZip.java
@@ -147,6 +147,12 @@ public class PluginZip {
             return this;
         }
 
+        public Builder pluginRequires(String pluginRequires) {
+            this.properties.put(PropertiesPluginDescriptorFinder.PLUGIN_REQUIRES, pluginRequires);
+
+            return this;
+        }
+
         /**
          * Add extra properties to the {@code properties} file.
          * As possible attribute name please see {@link PropertiesPluginDescriptorFinder}.


### PR DESCRIPTION
Fixes #630

  ## Problem

  When plugins fail to start or enable due to validation errors or exceptions, the PluginWrapper's failedException field is not always set. This makes it impossible for callers to programmatically determine why a plugin failed.

  ## Solution

  This PR ensures that failedException is consistently set in the following scenarios:

  1. **Plugin validation failure during load** - When a plugin doesn't meet system version requirements, failedException is now set with a generic message. The detailed reason remains in the warning log.

  2. **Exception during plugin stop** - When stopPlugins() catches an exception from plugin.stop(), the plugin is now marked as FAILED with the exception preserved. Previously, the exception was only logged and the plugin remained in STARTED state.

  3. **Validation failure during enable** - When enablePlugin() is called on an invalid plugin, failedException is now set before returning false.

  ## Test Coverage

  Added three comprehensive tests to verify the new behavior:
  - invalidPluginSetsFailedException
  - stopPluginsWithExceptionSetsFailedException
  - enableInvalidPluginSetsFailedException

  Also added PluginZip.Builder.pluginRequires() helper method and FailingStopPlugin test utility class.

