### PR TITLE
Allow customization of PluginClassLoader parent delegation

### DIFF
--- a/demo/gradle/app/src/main/java/org/pf4j/demo/Boot.java
+++ b/demo/gradle/app/src/main/java/org/pf4j/demo/Boot.java
@@ -18,6 +18,7 @@ package org.pf4j.demo;
 import org.apache.commons.lang3.StringUtils;
 import org.pf4j.CompoundPluginDescriptorFinder;
 import org.pf4j.ManifestPluginDescriptorFinder;
+import org.pf4j.PluginLoader;
 import org.pf4j.PropertiesPluginDescriptorFinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,13 @@ public class Boot {
                 // PropertiesPluginDescriptorFinder is commented out just to avoid error log
                 //.add(new PropertiesPluginDescriptorFinder())
                 .add(new ManifestPluginDescriptorFinder());
+          }
+
+          @Override
+          protected PluginLoader createPluginLoader() {
+            // Use custom DemoPluginLoader which uses DemoPluginClassLoader
+            // This demonstrates how to customize class loading behavior
+            return new DemoPluginLoader(this);
           }
         };
 

--- a/demo/gradle/app/src/main/java/org/pf4j/demo/DemoPluginClassLoader.java
+++ b/demo/gradle/app/src/main/java/org/pf4j/demo/DemoPluginClassLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import org.pf4j.PluginClassLoader;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+
+/**
+ * Custom PluginClassLoader that demonstrates how to exclude specific packages
+ * from parent delegation.
+ * <p>
+ * This allows demo plugins to load their own classes even if they're in the
+ * org.pf4j.demo package, which would normally be delegated to the parent classloader.
+ * <p>
+ * This pattern is useful for framework extensions (like PF4J-Plus) that need to
+ * customize class loading behavior for their own demo/test packages.
+ *
+ * @author Decebal Suiu
+ */
+class DemoPluginClassLoader extends PluginClassLoader {
+
+    public DemoPluginClassLoader(PluginManager pluginManager, PluginDescriptor pluginDescriptor, ClassLoader parent) {
+        super(pluginManager, pluginDescriptor, parent);
+    }
+
+    @Override
+    protected boolean shouldDelegateToParent(String className) {
+        // Call parent implementation but exclude org.pf4j.demo.* classes
+        // This demonstrates how to customize class loading for framework extensions
+        return super.shouldDelegateToParent(className)
+            && !className.startsWith("org.pf4j.demo");
+    }
+
+}

--- a/demo/gradle/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
+++ b/demo/gradle/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import org.pf4j.BasePluginLoader;
+import org.pf4j.DefaultPluginClasspath;
+import org.pf4j.PluginClassLoader;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+
+import java.nio.file.Path;
+
+/**
+ * Custom PluginLoader that uses {@link DemoPluginClassLoader} for loading plugins.
+ *
+ * @author Decebal Suiu
+ */
+class DemoPluginLoader extends BasePluginLoader {
+
+    public DemoPluginLoader(PluginManager pluginManager) {
+        super(pluginManager, new DefaultPluginClasspath());
+    }
+
+    @Override
+    protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+        return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+    }
+
+}

--- a/demo/gradle/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
+++ b/demo/gradle/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
@@ -15,8 +15,10 @@
  */
 package org.pf4j.demo;
 
-import org.pf4j.BasePluginLoader;
-import org.pf4j.DefaultPluginClasspath;
+import org.pf4j.DefaultPluginLoader;
+import org.pf4j.DevelopmentPluginLoader;
+import org.pf4j.JarPluginLoader;
+import org.pf4j.CompoundPluginLoader;
 import org.pf4j.PluginClassLoader;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginManager;
@@ -28,15 +30,27 @@ import java.nio.file.Path;
  *
  * @author Decebal Suiu
  */
-class DemoPluginLoader extends BasePluginLoader {
+class DemoPluginLoader extends CompoundPluginLoader {
 
     public DemoPluginLoader(PluginManager pluginManager) {
-        super(pluginManager, new DefaultPluginClasspath());
-    }
-
-    @Override
-    protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
-        return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+        add(new DevelopmentPluginLoader(pluginManager) {
+            @Override
+            protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+            }
+        }, pluginManager::isDevelopment);
+        add(new JarPluginLoader(pluginManager) {
+            @Override
+            protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+            }
+        }, pluginManager::isNotDevelopment);
+        add(new DefaultPluginLoader(pluginManager) {
+            @Override
+            protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+            }
+        }, pluginManager::isNotDevelopment);
     }
 
 }

--- a/demo/gradle/gradle.properties
+++ b/demo/gradle/gradle.properties
@@ -1,2 +1,2 @@
 # PF4J
-pf4jVersion=3.1.0
+pf4jVersion=3.15.0-SNAPSHOT

--- a/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginClassLoader.java
+++ b/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginClassLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import org.pf4j.PluginClassLoader;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+
+/**
+ * Custom PluginClassLoader that demonstrates how to exclude specific packages
+ * from parent delegation.
+ * <p>
+ * This allows demo plugins to load their own classes even if they're in the
+ * org.pf4j.demo package, which would normally be delegated to the parent classloader.
+ * <p>
+ * This pattern is useful for framework extensions (like PF4J-Plus) that need to
+ * customize class loading behavior for their own demo/test packages.
+ *
+ * @author Decebal Suiu
+ */
+class DemoPluginClassLoader extends PluginClassLoader {
+
+    public DemoPluginClassLoader(PluginManager pluginManager, PluginDescriptor pluginDescriptor, ClassLoader parent) {
+        super(pluginManager, pluginDescriptor, parent);
+    }
+
+    @Override
+    protected boolean shouldDelegateToParent(String className) {
+        // Call parent implementation but exclude org.pf4j.demo.* classes
+        // This demonstrates how to customize class loading for framework extensions
+        return super.shouldDelegateToParent(className)
+            && !className.startsWith("org.pf4j.demo");
+    }
+
+}

--- a/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
+++ b/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import org.pf4j.BasePluginLoader;
+import org.pf4j.DefaultPluginClasspath;
+import org.pf4j.PluginClassLoader;
+import org.pf4j.PluginDescriptor;
+import org.pf4j.PluginManager;
+
+import java.nio.file.Path;
+
+/**
+ * Custom PluginLoader that uses {@link DemoPluginClassLoader} for loading plugins.
+ *
+ * @author Decebal Suiu
+ */
+class DemoPluginLoader extends BasePluginLoader {
+
+    public DemoPluginLoader(PluginManager pluginManager) {
+        super(pluginManager, new DefaultPluginClasspath());
+    }
+
+    @Override
+    protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+        return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+    }
+
+}

--- a/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
+++ b/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginLoader.java
@@ -15,8 +15,10 @@
  */
 package org.pf4j.demo;
 
-import org.pf4j.BasePluginLoader;
-import org.pf4j.DefaultPluginClasspath;
+import org.pf4j.DefaultPluginLoader;
+import org.pf4j.DevelopmentPluginLoader;
+import org.pf4j.JarPluginLoader;
+import org.pf4j.CompoundPluginLoader;
 import org.pf4j.PluginClassLoader;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginManager;
@@ -28,15 +30,27 @@ import java.nio.file.Path;
  *
  * @author Decebal Suiu
  */
-class DemoPluginLoader extends BasePluginLoader {
+class DemoPluginLoader extends CompoundPluginLoader {
 
     public DemoPluginLoader(PluginManager pluginManager) {
-        super(pluginManager, new DefaultPluginClasspath());
-    }
-
-    @Override
-    protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
-        return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+        add(new DevelopmentPluginLoader(pluginManager) {
+            @Override
+            protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+            }
+        }, pluginManager::isDevelopment);
+        add(new JarPluginLoader(pluginManager) {
+            @Override
+            protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+            }
+        }, pluginManager::isNotDevelopment);
+        add(new DefaultPluginLoader(pluginManager) {
+            @Override
+            protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                return new DemoPluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+            }
+        }, pluginManager::isNotDevelopment);
     }
 
 }

--- a/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginManager.java
+++ b/demo/maven/app/src/main/java/org/pf4j/demo/DemoPluginManager.java
@@ -20,6 +20,7 @@ import org.pf4j.DefaultPluginFactory;
 import org.pf4j.DefaultPluginManager;
 import org.pf4j.ExtensionFinder;
 import org.pf4j.PluginFactory;
+import org.pf4j.PluginLoader;
 
 class DemoPluginManager extends DefaultPluginManager {
 
@@ -37,6 +38,13 @@ class DemoPluginManager extends DefaultPluginManager {
     @Override
     protected PluginFactory createPluginFactory() {
         return new DemoPluginFactory();
+    }
+
+    @Override
+    protected PluginLoader createPluginLoader() {
+        // Use custom DemoPluginLoader which uses DemoPluginClassLoader
+        // This demonstrates how to customize class loading behavior
+        return new DemoPluginLoader(this);
     }
 
 }

--- a/pf4j/src/main/java/org/pf4j/JarPluginLoader.java
+++ b/pf4j/src/main/java/org/pf4j/JarPluginLoader.java
@@ -38,10 +38,14 @@ public class JarPluginLoader implements PluginLoader {
 
     @Override
     public ClassLoader loadPlugin(Path pluginPath, PluginDescriptor pluginDescriptor) {
-        PluginClassLoader pluginClassLoader = new PluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
+        PluginClassLoader pluginClassLoader = createPluginClassLoader(pluginPath, pluginDescriptor);
         pluginClassLoader.addFile(pluginPath.toFile());
 
         return pluginClassLoader;
+    }
+
+    protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+        return new PluginClassLoader(pluginManager, pluginDescriptor, getClass().getClassLoader());
     }
 
 }

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -128,7 +128,7 @@ public class PluginClassLoader extends URLClassLoader {
             }
 
             // if the class is part of the plugin engine use parent class loader
-            if (className.startsWith(PLUGIN_PACKAGE_PREFIX) && !className.startsWith("org.pf4j.demo") && !className.startsWith("org.pf4j.test")) {
+            if (shouldDelegateToParent(className)) {
 //                log.trace("Delegate the loading of PF4J class '{}' to parent", className);
                 return getParent().loadClass(className);
             }
@@ -238,6 +238,23 @@ public class PluginClassLoader extends URLClassLoader {
             loadingStrategy = ClassLoadingStrategy.PAD;
         }
         return loadingStrategy;
+    }
+
+    /**
+     * Determines whether a class should be delegated to the parent class loader.
+     * <p>
+     * By default, classes in the {@code org.pf4j} package are delegated to the parent class loader,
+     * except for test utilities ({@code org.pf4j.test}) which are part of the plugin's test classpath.
+     * <p>
+     * This method can be overridden by subclasses to customize which packages should be excluded
+     * from parent delegation. This is useful for framework extensions or custom class loading policies.
+     *
+     * @param className the name of the class to check
+     * @return {@code true} if the class should be loaded by the parent class loader, {@code false} otherwise
+     */
+    protected boolean shouldDelegateToParent(String className) {
+        return className.startsWith(PLUGIN_PACKAGE_PREFIX)
+            && !className.startsWith("org.pf4j.test");
     }
 
     /**


### PR DESCRIPTION
## Summary
   Extracts hardcoded package exclusions from `PluginClassLoader` into a protected `shouldDelegateToParent()` method that can be overridden by subclasses.

   ## Problem
   Previously, the parent delegation logic was hardcoded to exclude `org.pf4j.demo` and `org.pf4j.test` packages. This prevented framework extensions (like PF4J-Plus) from customizing class loading behavior for
   their own demo or test packages.

   ## Solution
   - Add `protected boolean shouldDelegateToParent(String className)` method to `PluginClassLoader`
   - Remove `org.pf4j.demo` exclusion (not part of core framework)
   - Keep `org.pf4j.test` exclusion (part of core test utilities)
   - Provide working examples in both Maven and Gradle demos via custom `DemoPluginClassLoader` and `DemoPluginLoader` classes

   ## Changes
   - **PluginClassLoader.java**: Extract exclusion logic into overridable method
   - **PluginClassLoaderTest.java**: Add 5 new tests demonstrating override capability
   - **demo/gradle**: Add `DemoPluginClassLoader`, `DemoPluginLoader`; update to PF4J 3.15.0-SNAPSHOT
   - **demo/maven**: Add `DemoPluginClassLoader`, `DemoPluginLoader`

   ## Backwards Compatibility
   Fully backwards compatible. Follows existing pattern of protected factory methods used throughout the framework.

   ## Testing
   All tests pass (33/33 in PluginClassLoaderTest). New tests demonstrate:
   - Default behavior for PF4J core classes
   - Exclusions for test utilities
   - Override capability for custom packages (e.g., `org.pf4j.plus.demo`)

   Fixes #632