### PR TITLE
Automate Gradle demo version update after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,14 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Update Gradle demo version
+        run: |
+          RELEASE_VERSION="${{ github.event.inputs.releaseVersion }}"
+          sed -i "s/^pf4jVersion=.*/pf4jVersion=$RELEASE_VERSION/" demo/gradle/gradle.properties
+          git add demo/gradle/gradle.properties
+          git commit -m "Update Gradle demo to version $RELEASE_VERSION [skip ci]"
+          git push
+
       - name: Summary
         if: success()
         run: |

--- a/demo/gradle/gradle.properties
+++ b/demo/gradle/gradle.properties
@@ -1,2 +1,2 @@
 # PF4J
-pf4jVersion=3.15.0-SNAPSHOT
+pf4jVersion=3.15.0


### PR DESCRIPTION
## Summary
- Add step in `release.yml` workflow to automatically update `demo/gradle/gradle.properties` with the released version
- Update current `gradle.properties` to 3.15.0

## Why
The Gradle demo's `pf4jVersion` was not being updated after releases, causing it to be out of sync with the latest version. Users cloning the repo couldn't run the Gradle demo without manual changes.

## Changes
- `.github/workflows/release.yml`: Added "Update Gradle demo version" step after "Create GitHub Release"
- `demo/gradle/gradle.properties`: Updated to current release (3.15.0)

Fixes #646