### PR TITLE
Fail the build when the SonarCloud quality gate fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
                   # SONAR_TOKEN is not exposed to pull requests from forks, and the
                   # scanner fails hard without it. Build without analysis in that case.
                   if [ -n "$SONAR_TOKEN" ]; then
-                      cd pf4j && mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+                      cd pf4j && mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=true
                   else
                       echo "SONAR_TOKEN unavailable (fork pull request). Skipping analysis."
                       cd pf4j && mvn -B verify


### PR DESCRIPTION
Fixes #659

Adds `-Dsonar.qualitygate.wait=true` so the build waits for the analysis to finish and fails if the gate does not pass.

One thing to sort out before merging: the gate currently reports no status at all on `master`.

```
$ curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=pf4j_pf4j&branch=master"
{"projectStatus":{"status":"NONE","conditions":[],"periods":[]}}
```

The Sonar way gate is assigned and analyses are running, so the likely cause is that no New Code period is defined for the project. Every condition in that gate measures new code, so with no baseline there is nothing to evaluate and the flag would be a no-op. Needs setting under Project Settings, New Code, where "Previous version" fits a library like this.

This PR is also the first test of the change, since it runs analysis in pull request mode.