### PR TITLE
Wait for the quality gate only on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,17 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  # The gate is a merge guard, so wait for it only where it can still block
+                  # a merge. It is computed on new code, which SonarCloud derives from the
+                  # diff against the base branch. On master there is no such diff and no New
+                  # Code period, so the gate comes back as NONE and the scanner reads
+                  # anything but OK as a failure.
+                  QUALITY_GATE_WAIT: ${{ github.event_name == 'pull_request' }}
               run: |
                   # SONAR_TOKEN is not exposed to pull requests from forks, and the
                   # scanner fails hard without it. Build without analysis in that case.
                   if [ -n "$SONAR_TOKEN" ]; then
-                      cd pf4j && mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=true
+                      cd pf4j && mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.qualitygate.wait=$QUALITY_GATE_WAIT
                   else
                       echo "SONAR_TOKEN unavailable (fork pull request). Skipping analysis."
                       cd pf4j && mvn -B verify


### PR DESCRIPTION
Fixes #662.

The gate is computed on new code. Pull requests and short lived branches get that from the diff against the base branch. master has no New Code period, so SonarCloud returns `NONE` and the scanner reads anything but `OK` as a failure.

Waiting on master blocks nothing anyway, the merge already happened. The analysis still runs there and still feeds the dashboard and the coverage badge.