### PR TITLE
Detect breaking API changes with japicmp

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -121,6 +121,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <version>0.26.1</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <parameter>
+                        <onlyModified>true</onlyModified>
+                        <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                        <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fixes #658.

Adds japicmp to the `pf4j` module, bound to `verify`. It compares the built jar against the previously released one and fails the build on a binary or source incompatible change. Only `pf4j` is gated, the demo and the archetype are not published as API.

## Calibration

Run before touching the pom, with the japicmp CLI on the released jars, to make sure turning this on would not flag existing code:

| Comparison | Incompatibilities |
|---|---|
| 3.10.0 -> 3.11.1 | 0 |
| 3.11.1 -> 3.12.1 | 0 |
| 3.12.1 -> 3.13.0 | 0 |
| 3.13.0 -> 3.14.1 | **8** |
| 3.14.1 -> 3.15.0 | 0 |
| 3.15.0 -> 3.15.1 | 0 |
| 3.15.1 -> HEAD | 0 |

The suggested semantic version matched reality in every case: minor for 3.14.1 -> 3.15.0, patch for 3.15.0 -> 3.15.1.

## What the calibration found

3.14.0 narrowed the return type of the `DefaultPluginDescriptor` setters from `PluginDescriptor` to the concrete class:

```
***! MODIFIED METHOD: PUBLIC org.pf4j.DefaultPluginDescriptor (<-org.pf4j.PluginDescriptor) setLicense(java.lang.String)
```

A covariant return is source compatible, so recompiling works and nobody noticed. The JVM method descriptor includes the return type, so code compiled against 3.13.0 gets a `NoSuchMethodError` on 3.14.0. `setLicense` is public, the other seven are protected.

This is exactly what japicmp exists to catch, and it happened here. Nothing in this PR excludes it, since the baseline is the previous release and 3.14.0 is behind us. Worth a note in the changelog for 3.14.0 separately.

## Baseline

The previous release, resolved automatically. Confirmed from the generated report rather than assumed:

```
oldJar=".../org/pf4j/pf4j/3.15.1/pf4j-3.15.1.jar"
newJar=".../target/pf4j-3.16.0-SNAPSHOT.jar"
```

A pinned baseline would guarantee the whole 3.x line, but it would have to open with eight `<excludes>` recording the 3.14.0 break. The exclusion list is meant to be a record of deliberate decisions, and starting it with a past accident destroys that signal. Binary compatibility carries along the chain, so a clean step at every release gives the same guarantee going forward, with nothing to maintain.

## Proof that it fails

Reducing the visibility of a public method:

```
[ERROR] There is at least one incompatibility:
        org.pf4j.PluginStateEvent.getOldState():METHOD_LESS_ACCESSIBLE
```

Reverted. A green plugin is not a guard until you have seen it fail.

## Note on ignoreMissingClasses

An earlier version of this PR carried an `ignoreMissingClassesByRegularExpressions` entry for `org.objectweb.asm.*`. It is not needed, and anyone hitting the error below should not add it back.

The japicmp CLI fails with `Could not load 'org.objectweb.asm.AnnotationVisitor'` when given two jars and no classpath, because `asm` is `<optional>true</optional>` and therefore not transitive. The Maven plugin behaves differently: its default `classPathMode` is `ONE_COMMON_CLASSPATH`, built from the project dependencies, where `asm` is present even though it is optional. Removing the entry keeps the build green and drops the `You have ignored certain classes` warning, so the check is strictly stricter without it. If a genuinely missing class ever needs ignoring, prefer a narrow regex over the blanket `ignoreMissingClasses`, the way Apache Shiro does it.
