### PR TITLE
Note the binary incompatible setter change in 3.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#614]: Demo application shows zero Greeting extensions under JDK 23
 - Set class loader to null on unload plugin
 
+#### Changed
+- `DefaultPluginDescriptor` setters return the concrete type instead of `PluginDescriptor`, so that they can be chained. This is source compatible but not binary compatible, code compiled against 3.13.0 or earlier has to be recompiled.
+
 #### Added
 - [#598]: Add Maven wrapper
 


### PR DESCRIPTION
Found by the japicmp calibration in #664.

3.14.0 narrowed the return type of the `DefaultPluginDescriptor` setters from `PluginDescriptor` to the concrete class, in commit 28bb6ef, so that they could be chained. The interface only declares getters, so a setter returning it could not be chained with anything. The change was right, it was just never recorded as binary incompatible.

A covariant return is source compatible, so recompiling works and nobody noticed. The JVM method descriptor includes the return type, so code compiled against 3.13.0 gets a `NoSuchMethodError` on 3.14.0. `setLicense` is public, the other seven setters are protected.

This adds the entry to the released 3.14.0 section, where someone tracking down that error would look. Nothing in the build excludes it, the japicmp baseline is the previous release and 3.14.0 is behind it.