### PR TITLE
Check the multi-release layout of the built jar

### DIFF
--- a/pf4j/pom.xml
+++ b/pf4j/pom.xml
@@ -122,6 +122,23 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <pf4j.jar>${project.build.directory}/${project.build.finalName}.jar</pf4j.jar>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
                 <version>0.26.1</version>

--- a/pf4j/src/test/java/org/pf4j/MultiReleaseJarIT.java
+++ b/pf4j/src/test/java/org/pf4j/MultiReleaseJarIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Checks that the packaged jar keeps the layout that JPMS needs, so that consumers can write
+ * {@code requires org.pf4j;}.
+ * <p>
+ * This runs against the built artifact and not against {@code target/classes}, because that is what
+ * gets published. Both conditions below are needed. A jar that carries the module descriptor without
+ * the {@code Multi-Release} attribute is not read as a multi-release jar, and the module stays invisible.
+ * <p>
+ * Release 3.15.0 shipped without the descriptor, see #648. It was not caught by the build, because
+ * {@code module-info.java} had been deleted and the compiler execution that handles it silently
+ * compiled nothing.
+ *
+ * @author Decebal Suiu
+ */
+class MultiReleaseJarIT {
+
+    private static final String MODULE_INFO = "META-INF/versions/9/module-info.class";
+
+    @Test
+    void jarContainsModuleDescriptor() throws Exception {
+        try (JarFile jar = new JarFile(getJar())) {
+            JarEntry entry = jar.getJarEntry(MODULE_INFO);
+            assertNotNull(entry, MODULE_INFO + " is missing from the jar");
+            assertTrue(entry.getSize() > 0, MODULE_INFO + " is empty");
+        }
+    }
+
+    @Test
+    void jarIsMarkedAsMultiRelease() throws Exception {
+        try (JarFile jar = new JarFile(getJar())) {
+            Attributes attributes = jar.getManifest().getMainAttributes();
+            assertEquals("true", attributes.getValue("Multi-Release"),
+                "the Multi-Release manifest attribute is missing or not true");
+        }
+    }
+
+    private File getJar() {
+        String path = System.getProperty("pf4j.jar");
+        assertNotNull(path, "the pf4j.jar system property is not set");
+
+        File jar = new File(path);
+        assertTrue(jar.isFile(), "the jar was not found at " + path);
+
+        return jar;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.1</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.6</version>
                 </plugin>


### PR DESCRIPTION
Fixes #660.

Adds `MultiReleaseJarIT`, run by failsafe at `verify`, which opens the built jar and asserts the two things JPMS needs.

## Why the jar and not target/classes

The jar is what gets published. Checking `target/classes` would have caught #648, but it would not catch a `maven-jar-plugin` misconfiguration. The guard should not depend on the one failure mode we already know about.

## Why two assertions

`META-INF/versions/9/module-info.class` has to be in the jar, and `Multi-Release: true` has to be in the manifest. They are independent. A jar carrying the descriptor without the manifest attribute is not read as a multi-release jar, so the module stays invisible and the user sees the same `module not found: org.pf4j`.

The second scenario below proves they are independent: the first test passed while the second failed.

## What #648 actually was

`module-info.java` was deleted by accident in 20c2f80, a path traversal fix. The `java9-compile` execution has `<include>module-info.java</include>`, and an include that matches no file compiles nothing without complaining. Nothing failed, the whole suite passed, and 3.15.0 shipped without the descriptor. A user found it after the release.

## Verified

| Scenario | Result |
|---|---|
| Normal build | 302 tests + 2 IT, `BUILD SUCCESS` |
| `module-info.java` deleted, reproducing #648 | fails with `META-INF/versions/9/module-info.class is missing from the jar` |
| `Multi-Release` removed from the manifest | fails with `the Multi-Release manifest attribute is missing or not true` |

Both were reverted afterwards. A green plugin is not a guard until you have seen it fail.

## Notes

`*IT` is the failsafe default include, disjoint from the surefire defaults, so no `<includes>` configuration is needed. Both the `integration-test` and `verify` goals are bound: the first runs the tests without failing the build, the second is what turns a failure into a build failure.

Failsafe is pinned to 2.22.1 to match the surefire version already in `pluginManagement`, which is known to work with JUnit 5.4.0 here. Both are from 2018 and worth bumping, but that is a separate change with its own testing.
