### PR TITLE
Pin the SonarCloud scanner version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
                 </plugin>
 
                 <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>5.7.0.6970</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.6</version>


### PR DESCRIPTION
Every build warns about this:

```
[WARNING] Using an unspecified version instead of an explicit plugin version may
introduce breaking analysis changes at an unwanted time.
```

The workflow invokes `org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` without a version, so CI takes whatever is newest on Central at that moment. A new scanner release can change the analysis, or fail the build, with nothing in the repository having changed.

Pinned in `pluginManagement` rather than in the workflow command. Maven honours it for a command line invocation too, verified by putting 4.0.0.4121 there and watching it resolve `sonar:4.0.0.4121:sonar` instead of the latest. Doing it this way keeps `build.yml` untouched and means a local `mvn sonar:sonar` runs the same version as CI.

5.7.0.6970 is what CI resolves today, so nothing changes now. It just stops changing on its own.