### PR TITLE
Add four projects to the Trusted By list, drop the star badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ Plugin Framework for Java (PF4J)
 
 ## Trusted By
 
-- **Netflix Spinnaker** - Continuous delivery platform  
+- **Netflix Spinnaker** - Continuous delivery platform, its plugin SDK is built on PF4J
 - **Facebook Buck** (Java version) - Build system
 - **Huawei Cloud** - Real-time data processing and scoring systems (MRS - MapReduce Service)
 - **Eclipse Foundation** - Connected Services Platform (ECSP) for automotive software-defined vehicles
 - **Dremio** (now part of SAP) - Data lakehouse platform, with its own plugin manager and class loaders built on PF4J
+- **MuleSoft Anypoint Code Builder** (Salesforce) - Mule DX Runtime loads its IDE component servers as PF4J plugins
 - **Apache Tika** - Content detection and extraction toolkit, uses PF4J for its pipes plugins
-- **Appsmith** [![GitHub stars](https://img.shields.io/github/stars/appsmithorg/appsmith.svg)](https://github.com/appsmithorg/appsmith) - Low-code application platform
-- **Halo CMS** [![GitHub stars](https://img.shields.io/github/stars/halo-dev/halo.svg)](https://github.com/halo-dev/halo) - Modern content management  
-- **[View more projects...](https://github.com/pf4j/pf4j/issues/173)**
+- **Apache BifroMQ** - Distributed MQTT broker, uses PF4J for its auth, throttling and event collector plugins
+- **Appsmith** - Low-code application platform
+- **Nextflow** - Workflow engine, the de facto standard for bioinformatics pipelines
+- **ReportPortal** - Test automation dashboard, with a plugin marketplace built on pf4j-update
+- **Halo CMS** - Modern content management
+- **[More projects...](https://github.com/pf4j/pf4j/discussions/620)**
 
 ---
 


### PR DESCRIPTION
Four projects verified this week and added to the list.

**MuleSoft Anypoint Code Builder.** The Mule DX Runtime starts a `DefaultPluginManager` and loads `mule-dev-core`, the DataWeave and APIKit component servers and the API server as plugins, each in its own `PluginClassLoader`. Evidence is a product log in forcedotcom/try-acb-feedback#40, PF4J 3.7.1 in deployment mode. The product is closed source, so the entry names no version.

**Apache BifroMQ.** Distributed MQTT broker. Plugins cover authentication, authorization, throttling, event collection and settings.

**Nextflow.** Workflow engine for scientific pipelines. No project from that domain was on the list.

**ReportPortal.** `Pf4jPluginBox`, and the only public adopter that also uses `pf4j-update` with `DefaultUpdateRepository`.

Gitblit was considered and left out. Only its NOTICE file mentions PF4J and nothing in the code does.

Two other changes while here. The star badges are gone from every entry: they measure popularity rather than how the project uses PF4J, and putting the counts side by side invites a comparison that is not the point of the list. Each entry now says what it demonstrates instead. The "more projects" link pointed at issue #173, which is closed, and now points at discussion #620.
