### PR TITLE
Read extension annotations from recent class files (fixes #669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### [Unreleased][unreleased]
 
 #### Fixed
+- [#669]: Read extension annotations from class files produced by recent Java releases
 
 #### Changed
 
@@ -559,6 +560,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.11.0]: https://github.com/decebals/pf4j/compare/release-0.10.0...release-0.11.0
 [0.10.0]: https://github.com/decebals/pf4j/compare/release-0.9.0...release-0.10.0
 
+[#669]: https://github.com/pf4j/pf4j/issues/669
 [#656]: https://github.com/pf4j/pf4j/issues/656
 [#648]: https://github.com/pf4j/pf4j/issues/648
 [#646]: https://github.com/pf4j/pf4j/issues/646

--- a/pf4j/src/main/java/org/pf4j/asm/ExtensionInfo.java
+++ b/pf4j/src/main/java/org/pf4j/asm/ExtensionInfo.java
@@ -99,6 +99,12 @@ public final class ExtensionInfo {
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             return null;
+        } catch (RuntimeException e) {
+            // The class file cannot be parsed by the bundled ASM version, for example because it was
+            // compiled for a newer Java release. Skip this extension instead of aborting the whole
+            // extension discovery, see https://github.com/pf4j/pf4j/issues/669.
+            log.error("Cannot read the extension annotation of '{}'", className, e);
+            return null;
         }
     }
 

--- a/pf4j/src/main/java/org/pf4j/asm/ExtensionVisitor.java
+++ b/pf4j/src/main/java/org/pf4j/asm/ExtensionVisitor.java
@@ -42,7 +42,7 @@ class ExtensionVisitor extends ClassVisitor {
     
     private static final Logger log = LoggerFactory.getLogger(ExtensionVisitor.class);
 
-    private static final int ASM_VERSION = Opcodes.ASM7;
+    private static final int ASM_VERSION = Opcodes.ASM9;
 
     private final ExtensionInfo extensionInfo;
 

--- a/pf4j/src/test/java/org/pf4j/asm/ExtensionInfoTest.java
+++ b/pf4j/src/test/java/org/pf4j/asm/ExtensionInfoTest.java
@@ -16,6 +16,16 @@
 package org.pf4j.asm;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.RecordComponentVisitor;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,6 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExtensionInfoTest {
+
+    private static final String PROBE_CLASS_NAME = "ExtensionProbe";
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void loadShouldReturnExtensionInfoWhenClassExists() {
@@ -59,6 +74,95 @@ class ExtensionInfoTest {
     void getPointsShouldReturnEmptyListWhenNotSet() {
         ExtensionInfo info = new ExtensionInfo("org.pf4j.asm.ExtensionInfo");
         assertTrue(info.getPoints().isEmpty());
+    }
+
+    /**
+     * The bundled ASM version must be able to read class files produced by recent Java releases.
+     * See <a href="https://github.com/pf4j/pf4j/issues/669">#669</a>.
+     */
+    @Test
+    void loadShouldReadAnnotationFromRecentClassFileVersion() throws Exception {
+        ExtensionInfo info = loadProbe(probe(Opcodes.V21, false, false));
+
+        assertNotNull(info);
+        assertTrue(info.getPlugins().contains("alpha"));
+    }
+
+    /**
+     * A class file that cannot be parsed must not abort the whole extension discovery.
+     * See <a href="https://github.com/pf4j/pf4j/issues/669">#669</a>.
+     */
+    @Test
+    void loadShouldReturnNullForUnsupportedClassFileVersion() throws Exception {
+        byte[] bytes = probe(Opcodes.V21, false, false);
+        // pretend the class was compiled by a Java release that ASM does not know yet
+        bytes[6] = 0;
+        bytes[7] = (byte) 99;
+
+        assertNull(loadProbe(bytes));
+    }
+
+    /**
+     * A record annotated with {@code @Extension} carries a {@code Record} attribute, which requires
+     * at least the ASM8 API level. See <a href="https://github.com/pf4j/pf4j/issues/669">#669</a>.
+     */
+    @Test
+    void loadShouldReadAnnotationFromRecord() throws Exception {
+        ExtensionInfo info = loadProbe(probe(Opcodes.V21, true, false));
+
+        assertNotNull(info);
+        assertTrue(info.getPlugins().contains("alpha"));
+    }
+
+    /**
+     * A sealed class annotated with {@code @Extension} carries a {@code PermittedSubclasses}
+     * attribute, which requires at least the ASM9 API level.
+     * See <a href="https://github.com/pf4j/pf4j/issues/669">#669</a>.
+     */
+    @Test
+    void loadShouldReadAnnotationFromSealedClass() throws Exception {
+        ExtensionInfo info = loadProbe(probe(Opcodes.V21, false, true));
+
+        assertNotNull(info);
+        assertTrue(info.getPlugins().contains("alpha"));
+    }
+
+    /**
+     * Generates a class annotated with {@code @Extension(plugins = "alpha")}. The class is built with
+     * ASM rather than compiled, so that class file features newer than the compiler release used for
+     * the tests can be covered as well.
+     */
+    private static byte[] probe(int classFileVersion, boolean record, boolean sealed) {
+        ClassWriter classWriter = new ClassWriter(0);
+        classWriter.visit(classFileVersion, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, PROBE_CLASS_NAME,
+            null, record ? "java/lang/Record" : "java/lang/Object", null);
+
+        AnnotationVisitor annotationVisitor = classWriter.visitAnnotation("Lorg/pf4j/Extension;", true);
+        AnnotationVisitor pluginsVisitor = annotationVisitor.visitArray("plugins");
+        pluginsVisitor.visit(null, "alpha");
+        pluginsVisitor.visitEnd();
+        annotationVisitor.visitEnd();
+
+        if (record) {
+            RecordComponentVisitor recordComponentVisitor = classWriter.visitRecordComponent("value", "I", null);
+            recordComponentVisitor.visitEnd();
+        }
+        if (sealed) {
+            classWriter.visitPermittedSubclass(PROBE_CLASS_NAME + "Subclass");
+        }
+
+        classWriter.visitEnd();
+
+        return classWriter.toByteArray();
+    }
+
+    private ExtensionInfo loadProbe(byte[] bytes) throws Exception {
+        Path classFile = Files.createTempDirectory(tempDir, "probe").resolve(PROBE_CLASS_NAME + ".class");
+        Files.write(classFile, bytes);
+
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[]{classFile.getParent().toUri().toURL()}, null)) {
+            return ExtensionInfo.load(PROBE_CLASS_NAME, classLoader);
+        }
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.release>8</maven.compiler.release>
 
         <slf4j.version>2.0.6</slf4j.version>
-        <asm.version>9.1</asm.version>
+        <asm.version>9.9.1</asm.version>
 
         <junit.version>5.4.0</junit.version>
         <hamcrest.version>2.1</hamcrest.version>


### PR DESCRIPTION
Fixes #669.

While fixing the reported problem I found a second way to reach the same failure, so this PR covers three changes.

### 1. Bump asm from 9.1 to 9.9.1

ASM 9.1 rejects class files newer than Java 17 with `IllegalArgumentException: Unsupported class file major version 65`. 9.9.1 knows up to `V26`. The property was last touched in April 2021 and had gone stale.

ASM 9.9.1 is still compiled to class file version 49 (Java 5), so the Java 8 baseline of pf4j is not affected. The dependency stays `optional` and `requires static`.

### 2. Raise the visitor API level from ASM7 to ASM9

This one is independent of the class file version and is the reason a plain version bump would not have been enough. `ExtensionVisitor` passed `Opcodes.ASM7` to `ClassVisitor`, and ASM refuses to report newer class file attributes at that level:

```
plain  class, v21 -> plugins=[alpha]
record class, v21 -> THROWS UnsupportedOperationException: Records requires ASM8
sealed class, v21 -> THROWS UnsupportedOperationException: PermittedSubclasses requires ASM9
```

So an extension declared as a record or as a sealed class failed regardless of the target release, including class files compiled for Java 16.

### 3. Do not let a parse failure abort extension discovery

Both exceptions above are unchecked. `ExtensionInfo.load` only caught `IOException`, and `AbstractExtensionFinder` only catches `ClassNotFoundException` and `NoClassDefFoundError`, so the exception propagated out of `find(Class)` and killed discovery for every remaining extension, not just the offending one.

`load` now also catches `RuntimeException`, logs the class name and returns `null`, which the caller already treats as "skip this extension". `Error` is deliberately not caught, so the existing handling of a missing ASM library upstream is unchanged.

This is the same failure shape as #297, where the fix was widening the catch clause as well.

### Tests

Four regression tests in `ExtensionInfoTest`, one per case: recent class file version, unsupported class file version, record, sealed class.

The probe classes are generated with `ClassWriter` instead of being compiled, because the test sources are compiled with `maven.compiler.release=8` and could not express a record or a sealed class otherwise. It also keeps the tests independent of the JDK running the build.

Full module suite is green locally.
