### PR TITLE
Read the ordinal attribute of the Extension annotation (fixes #670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Fixed
 - [#669]: Read extension annotations from class files produced by recent Java releases
+- [#670]: Read the `ordinal` attribute of the `Extension` annotation via ASM
 
 #### Changed
 
@@ -560,6 +561,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.11.0]: https://github.com/decebals/pf4j/compare/release-0.10.0...release-0.11.0
 [0.10.0]: https://github.com/decebals/pf4j/compare/release-0.9.0...release-0.10.0
 
+[#670]: https://github.com/pf4j/pf4j/issues/670
 [#669]: https://github.com/pf4j/pf4j/issues/669
 [#656]: https://github.com/pf4j/pf4j/issues/656
 [#648]: https://github.com/pf4j/pf4j/issues/648

--- a/pf4j/src/main/java/org/pf4j/asm/ExtensionVisitor.java
+++ b/pf4j/src/main/java/org/pf4j/asm/ExtensionVisitor.java
@@ -61,16 +61,25 @@ class ExtensionVisitor extends ClassVisitor {
         return new AnnotationVisitor(ASM_VERSION) {
 
             @Override
+            public void visit(String name, Object value) {
+                // "ordinal" is a scalar attribute, therefore it is reported here and not in visitArray
+                if ("ordinal".equals(name)) {
+                    log.debug("Load annotation attribute {} = {} ({})", name, value, value.getClass().getName());
+                    extensionInfo.ordinal = ((Number) value).intValue();
+                }
+
+                super.visit(name, value);
+            }
+
+            @Override
             public AnnotationVisitor visitArray(final String name) {
-                if ("ordinal".equals(name) || "plugins".equals(name) || "points".equals(name)) {
+                if ("plugins".equals(name) || "points".equals(name)) {
                     return new AnnotationVisitor(ASM_VERSION, super.visitArray(name)) {
 
                         @Override
                         public void visit(String key, Object value) {
                             log.debug("Load annotation attribute {} = {} ({})", name, value, value.getClass().getName());
-                            if ("ordinal".equals(name)) {
-                                extensionInfo.ordinal = Integer.parseInt(value.toString());
-                            } else if ("plugins".equals(name)) {
+                            if ("plugins".equals(name)) {
                                 if (value instanceof String) {
                                     log.debug("Found plugin {}", value);
                                     extensionInfo.plugins.add((String) value);

--- a/pf4j/src/test/java/org/pf4j/asm/ExtensionVisitorTest.java
+++ b/pf4j/src/test/java/org/pf4j/asm/ExtensionVisitorTest.java
@@ -15,10 +15,23 @@
  */
 package org.pf4j.asm;
 
+import com.google.testing.compile.JavaFileObjects;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Type;
+import org.pf4j.test.JavaFileObjectUtils;
+import org.pf4j.test.JavaSources;
+
+import javax.tools.JavaFileObject;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,6 +39,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExtensionVisitorTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void visitAnnotationShouldReturnExtensionAnnotationVisitor() {
@@ -47,17 +63,20 @@ class ExtensionVisitorTest {
         assertNull(returnedVisitor);
     }
 
+    /**
+     * {@code ordinal} is a scalar attribute, so ASM reports it through {@code visit} and never
+     * through {@code visitArray}. See <a href="https://github.com/pf4j/pf4j/issues/670">#670</a>.
+     */
     @Test
-    void visitArrayShouldHandleOrdinalAttribute() {
+    void visitShouldHandleOrdinalAttribute() {
         ExtensionInfo extensionInfo = new ExtensionInfo("org.pf4j.asm.ExtensionInfo");
         ClassVisitor extensionVisitor = new ExtensionVisitor(extensionInfo);
 
         AnnotationVisitor annotationVisitor = extensionVisitor.visitAnnotation("Lorg/pf4j/Extension;", true);
-        AnnotationVisitor arrayVisitor = annotationVisitor.visitArray("ordinal");
 
-        arrayVisitor.visit("key", 1);
+        annotationVisitor.visit("ordinal", 5);
 
-        assertEquals(1, extensionInfo.getOrdinal());
+        assertEquals(5, extensionInfo.getOrdinal());
     }
 
     @Test
@@ -84,6 +103,53 @@ class ExtensionVisitorTest {
         arrayVisitor.visit("key", Type.getType("Lorg/pf4j/Point;"));
 
         assertTrue(extensionInfo.getPoints().contains("org.pf4j.Point"));
+    }
+
+    /**
+     * Reads every attribute of an {@link org.pf4j.Extension} annotation from a class produced by
+     * javac, rather than from hand made visitor calls.
+     */
+    @Test
+    void shouldReadAllAttributesFromCompiledExtension() throws Exception {
+        JavaFileObject source = JavaFileObjects.forSourceLines("OrdinalGreeting",
+            "package test;",
+            "import org.pf4j.Extension;",
+            "",
+            "@Extension(ordinal = 5, plugins = {\"alpha\", \"beta\"}, points = {Greeting.class})",
+            "public class OrdinalGreeting implements Greeting {",
+            "",
+            "    @Override",
+            "    public String getGreeting() {",
+            "        return \"Ordinal\";",
+            "    }",
+            "",
+            "}");
+
+        ClassLoader classLoader = writeClasses(JavaSources.compileAll(JavaSources.GREETING, source));
+        ExtensionInfo extensionInfo = ExtensionInfo.load("test.OrdinalGreeting", classLoader);
+
+        assertNotNull(extensionInfo);
+        assertEquals(5, extensionInfo.getOrdinal());
+        assertEquals(Arrays.asList("alpha", "beta"), extensionInfo.getPlugins());
+        assertEquals(Collections.singletonList(JavaSources.GREETING_CLASS_NAME), extensionInfo.getPoints());
+    }
+
+    /**
+     * Writes the compiled classes to a directory, so that they can be read as resources by
+     * {@link ExtensionInfo#load(String, ClassLoader)}.
+     */
+    private ClassLoader writeClasses(List<JavaFileObject> objects) throws Exception {
+        for (JavaFileObject object : objects) {
+            if (object.getKind() != JavaFileObject.Kind.CLASS) {
+                continue;
+            }
+
+            Path classFile = tempDir.resolve(JavaFileObjectUtils.getClassName(object).replace('.', '/') + ".class");
+            Files.createDirectories(classFile.getParent());
+            Files.write(classFile, JavaFileObjectUtils.getAllBytes(object));
+        }
+
+        return new URLClassLoader(new URL[]{tempDir.toUri().toURL()}, null);
     }
 
 }


### PR DESCRIPTION
Fixes #670.

### The problem

`ExtensionVisitor` handled `"ordinal"` inside `visitArray`, but `ordinal` is declared as a scalar:

```java
int ordinal() default 0;
```

ASM reports scalar annotation members through `AnnotationVisitor.visit(name, value)`, which was not overridden. The `"ordinal"` branch inside `visitArray` was therefore unreachable from real bytecode, and `ExtensionInfo.getOrdinal()` always returned 0.

Reading a class annotated `@Extension(ordinal = 5, plugins = {"alpha", "beta"}, points = {Greeting.class})` gave:

```
ordinal = 0        <-- expected 5
plugins = [alpha, beta]
points  = [test.Greeting]
```

### Impact

Not observable at runtime. `ExtensionInfo.getOrdinal()` has no production callers, and extension sorting goes through `ExtensionWrapper.getOrdinal()`, which reads the annotation reflectively and was always correct. So this is a public method on an exported class returning wrong data, not a behaviour change for users.

### Why the tests did not catch it

`visitArrayShouldHandleOrdinalAttribute` called `annotationVisitor.visitArray("ordinal")` directly, which is a call ASM never makes for a scalar member, so it asserted against the dead branch. `ExtensionInfoTest` only checked the default of 0 on a class carrying no annotation at all.

### Changes

The attribute is read in an overridden `visit`, and the dead branch in `visitArray` is removed. The old test now goes through `visit`, and there is a new end-to-end test that compiles a class with javac (using the existing `JavaSources` helper) and asserts all three attributes.

Both tests fail without the fix:

```
Tests run: 6, Failures: 2
  shouldReadAllAttributesFromCompiledExtension
  visitShouldHandleOrdinalAttribute
```

The test compiles in memory and writes to a `@TempDir`, so no new `@Extension` class enters the test classpath and `extensions.idx` is unchanged.

Full module suite green locally: 303 tests, 0 failures, 0 errors.

### Note

Independent of #671, which touches the same file on a different line. `ExtensionVisitor.java` merges
cleanly either way. Both branches do add a line to the same spot in CHANGELOG.md, so whichever one is
merged second needs that single line resolved.

