### PR TITLE
Fix the parent-first test for extensions.idx (fixes #674)

### DIFF
--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -352,7 +352,7 @@ class PluginClassLoaderTest {
 
     @Test
     void parentFirstGetExtensionsIndexExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
-        URL resource = parentLastPluginClassLoader.getResource(LegacyExtensionFinder.EXTENSIONS_RESOURCE);
+        URL resource = parentFirstPluginClassLoader.getResource(LegacyExtensionFinder.EXTENSIONS_RESOURCE);
         assertFirstLine("plugin", resource);
     }
 


### PR DESCRIPTION
The two tests for `extensions.idx` were identical, both asking `parentLastPluginClassLoader` for the resource, so the parent-first case from #449 was never covered.

Checked that the test now catches a regression: with the strategy override from #586 removed, `parentFirstGetExtensionsIndexExistsInParentAndDependencyAndPlugin` fails with `expected: <plugin> but was: <parent>`, the exact symptom from #449, while the parent-last test still passes.