### PR TITLE
Read the extensions index of a plugin from the plugin itself (fixes #673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 #### Fixed
 - [#669]: Read extension annotations from class files produced by recent Java releases
 - [#670]: Read the `ordinal` attribute of the `Extension` annotation via ASM
+- [#673]: Do not report the extensions of a dependency or of the application as extensions of a plugin
+- [#676]: Read the extensions of a plugin loaded with a custom class loader without a `ClassCastException`
 
 #### Changed
+- [#673]: Read the extensions index of a plugin from every jar on the plugin classpath
 
 #### Added
 
@@ -561,6 +564,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.11.0]: https://github.com/decebals/pf4j/compare/release-0.10.0...release-0.11.0
 [0.10.0]: https://github.com/decebals/pf4j/compare/release-0.9.0...release-0.10.0
 
+[#676]: https://github.com/pf4j/pf4j/issues/676
+[#673]: https://github.com/pf4j/pf4j/issues/673
 [#670]: https://github.com/pf4j/pf4j/issues/670
 [#669]: https://github.com/pf4j/pf4j/issues/669
 [#656]: https://github.com/pf4j/pf4j/issues/656

--- a/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
@@ -20,9 +20,13 @@ import org.pf4j.util.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,6 +52,24 @@ public abstract class AbstractExtensionFinder implements ExtensionFinder, Plugin
     public abstract Map<String, Set<String>> readPluginsStorages();
 
     public abstract Map<String, Set<String>> readClasspathStorages();
+
+    /**
+     * Looks up a storage resource in the plugin itself, without consulting the application or the
+     * dependencies of the plugin. Those declare their own extensions and are read on their own turn.
+     * <p>
+     * A plugin loaded with a class loader that is not a {@link URLClassLoader} cannot be searched in
+     * isolation, such a class loader decides alone what it makes visible.
+     *
+     * @param classLoader the class loader of the plugin
+     * @param name the name of the resource
+     * @return an enumeration of {@link URL} objects for the resource
+     * @throws IOException if I/O errors occur
+     */
+    protected Enumeration<URL> findStorageResources(ClassLoader classLoader, String name) throws IOException {
+        return classLoader instanceof URLClassLoader
+            ? ((URLClassLoader) classLoader).findResources(name)
+            : classLoader.getResources(name);
+    }
 
     @Override
     public <T> List<ExtensionWrapper<T>> find(Class<T> type) {

--- a/pf4j/src/main/java/org/pf4j/IndexedExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/IndexedExtensionFinder.java
@@ -89,13 +89,11 @@ public class IndexedExtensionFinder extends AbstractExtensionFinder {
 
             try {
                 log.debug("Read '{}'", EXTENSIONS_RESOURCE);
-                ClassLoader pluginClassLoader = plugin.getPluginClassLoader();
-                try (InputStream resourceStream = pluginClassLoader.getResourceAsStream(EXTENSIONS_RESOURCE)) {
-                    if (resourceStream == null) {
-                        log.debug("Cannot find '{}'", EXTENSIONS_RESOURCE);
-                    } else {
-                        collectExtensions(resourceStream, bucket);
-                    }
+                Enumeration<URL> urls = findStorageResources(plugin.getPluginClassLoader(), EXTENSIONS_RESOURCE);
+                if (urls.hasMoreElements()) {
+                    collectExtensions(urls, bucket);
+                } else {
+                    log.debug("Cannot find '{}'", EXTENSIONS_RESOURCE);
                 }
 
                 debugExtensions(bucket);

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -315,14 +315,16 @@ public class PluginClassLoader extends URLClassLoader {
         log.trace("Search in dependencies for resource '{}'", name);
         List<PluginDependency> dependencies = pluginDescriptor.getDependencies();
         for (PluginDependency dependency : dependencies) {
-            PluginClassLoader classLoader = (PluginClassLoader) pluginManager.getPluginClassLoader(dependency.getPluginId());
+            ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
             if (classLoader == null && dependency.isOptional()) {
                 continue;
             }
 
-            URL url = classLoader.findResource(name);
+            URL url = classLoader instanceof URLClassLoader
+                ? ((URLClassLoader) classLoader).findResource(name)
+                : classLoader.getResource(name);
             if (Objects.nonNull(url)) {
                 return url;
             }
@@ -343,14 +345,16 @@ public class PluginClassLoader extends URLClassLoader {
         List<URL> results = new ArrayList<>();
         List<PluginDependency> dependencies = pluginDescriptor.getDependencies();
         for (PluginDependency dependency : dependencies) {
-            PluginClassLoader classLoader = (PluginClassLoader) pluginManager.getPluginClassLoader(dependency.getPluginId());
+            ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
 
             // If the dependency is marked as optional, its class loader might not be available.
             if (classLoader == null && dependency.isOptional()) {
                 continue;
             }
 
-            results.addAll(Collections.list(classLoader.findResources(name)));
+            results.addAll(Collections.list(classLoader instanceof URLClassLoader
+                ? ((URLClassLoader) classLoader).findResources(name)
+                : classLoader.getResources(name)));
         }
 
         return results;

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -181,9 +181,8 @@ public class PluginClassLoader extends URLClassLoader {
      */
     @Override
     public URL getResource(String name) {
-        ClassLoadingStrategy loadingStrategy = getClassLoadingStrategy(name);
         log.trace("Received request to load resource '{}'", name);
-        for (ClassLoadingStrategy.Source classLoadingSource : loadingStrategy.getSources()) {
+        for (ClassLoadingStrategy.Source classLoadingSource : classLoadingStrategy.getSources()) {
             URL url = null;
             switch (classLoadingSource) {
                 case APPLICATION:
@@ -211,9 +210,8 @@ public class PluginClassLoader extends URLClassLoader {
     @Override
     public Enumeration<URL> getResources(String name) throws IOException {
         List<URL> resources = new ArrayList<>();
-        ClassLoadingStrategy loadingStrategy = getClassLoadingStrategy(name);
         log.trace("Received request to load resources '{}'", name);
-        for (ClassLoadingStrategy.Source classLoadingSource : loadingStrategy.getSources()) {
+        for (ClassLoadingStrategy.Source classLoadingSource : classLoadingStrategy.getSources()) {
             switch (classLoadingSource) {
                 case APPLICATION:
                     if (getParent() != null) {
@@ -230,14 +228,6 @@ public class PluginClassLoader extends URLClassLoader {
         }
 
         return Collections.enumeration(resources);
-    }
-
-    private ClassLoadingStrategy getClassLoadingStrategy(String name) {
-        ClassLoadingStrategy loadingStrategy = classLoadingStrategy;
-        if (IndexedExtensionFinder.EXTENSIONS_RESOURCE.equals(name)) {
-            loadingStrategy = ClassLoadingStrategy.PAD;
-        }
-        return loadingStrategy;
     }
 
     /**

--- a/pf4j/src/main/java/org/pf4j/ServiceProviderExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/ServiceProviderExtensionFinder.java
@@ -93,7 +93,7 @@ public class ServiceProviderExtensionFinder extends AbstractExtensionFinder {
             final Set<String> bucket = new HashSet<>();
 
             try {
-                Enumeration<URL> urls = findExtensionResource((PluginClassLoader) plugin.getPluginClassLoader());
+                Enumeration<URL> urls = findStorageResources(plugin.getPluginClassLoader(), EXTENSIONS_RESOURCE);
                 if (urls.hasMoreElements()) {
                     collectExtensions(urls, bucket);
                 } else {
@@ -113,10 +113,6 @@ public class ServiceProviderExtensionFinder extends AbstractExtensionFinder {
 
     Enumeration<URL> getExtensionResource(ClassLoader classLoader) throws IOException {
         return classLoader.getResources(EXTENSIONS_RESOURCE);
-    }
-
-    Enumeration<URL> findExtensionResource(PluginClassLoader classLoader) throws IOException {
-        return classLoader.findResources(EXTENSIONS_RESOURCE);
     }
 
     private void collectExtensions(Enumeration<URL> urls, Set<String> bucket) throws URISyntaxException, IOException {

--- a/pf4j/src/test/java/org/pf4j/IndexedExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/IndexedExtensionFinderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pf4j.test.PluginJar;
+import org.pf4j.test.TestExtension;
+import org.pf4j.test.TestPlugin;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class IndexedExtensionFinderTest {
+
+    @TempDir
+    Path pluginsPath;
+
+    @TempDir
+    Path applicationPath;
+
+    /**
+     * The application has its own {@code extensions.idx} and the plugin is loaded with
+     * {@link ClassLoadingStrategy#APD}, so the application is consulted first. The extensions of the
+     * plugin still have to be read from the plugin, see #449.
+     */
+    @Test
+    public void shouldFindPluginExtensionsWhenApplicationComesFirst() throws Exception {
+        PluginJar pluginJar = new PluginJar.Builder(pluginsPath.resolve("test-plugin.jar"), "test-plugin")
+                .pluginClass(TestPlugin.class.getName())
+                .pluginVersion("1.2.3")
+                .extension(TestExtension.class.getName())
+                .build();
+
+        ClassLoader applicationClassLoader = createApplicationClassLoader();
+
+        PluginManager pluginManager = new JarPluginManager(pluginsPath) {
+
+            @Override
+            protected PluginLoader createPluginLoader() {
+                return new JarPluginLoader(this) {
+
+                    @Override
+                    protected PluginClassLoader createPluginClassLoader(Path pluginPath, PluginDescriptor pluginDescriptor) {
+                        return new PluginClassLoader(pluginManager, pluginDescriptor, applicationClassLoader,
+                            ClassLoadingStrategy.APD);
+                    }
+
+                };
+            }
+
+        };
+
+        pluginManager.loadPlugins();
+
+        assertEquals(1, pluginManager.getPlugins().size());
+
+        IndexedExtensionFinder extensionFinder = new IndexedExtensionFinder(pluginManager);
+        Map<String, Set<String>> pluginsStorages = extensionFinder.readPluginsStorages();
+
+        Set<String> pluginStorage = pluginsStorages.get(pluginJar.pluginId());
+        assertNotNull(pluginStorage);
+        assertThat(pluginStorage, contains(TestExtension.class.getName()));
+    }
+
+    /**
+     * A plugin without an extensions index of its own declares no extensions. The extensions of a
+     * dependency belong to that dependency, which is read on its own turn.
+     */
+    @Test
+    public void shouldNotReadTheExtensionsOfADependency() throws Exception {
+        new PluginJar.Builder(pluginsPath.resolve("plugin-a.jar"), "plugin-a")
+                .pluginVersion("1.0.0")
+                .extension(TestExtension.class.getName())
+                .build();
+
+        new PluginJar.Builder(pluginsPath.resolve("plugin-b.jar"), "plugin-b")
+                .pluginVersion("1.0.0")
+                .manifestAttribute(ManifestPluginDescriptorFinder.PLUGIN_DEPENDENCIES, "plugin-a")
+                .build();
+
+        PluginManager pluginManager = new JarPluginManager(pluginsPath);
+        pluginManager.loadPlugins();
+
+        assertEquals(2, pluginManager.getPlugins().size());
+
+        IndexedExtensionFinder extensionFinder = new IndexedExtensionFinder(pluginManager);
+        Map<String, Set<String>> pluginsStorages = extensionFinder.readPluginsStorages();
+
+        assertThat(pluginsStorages.get("plugin-a"), contains(TestExtension.class.getName()));
+        assertEquals(Collections.emptySet(), pluginsStorages.get("plugin-b"));
+    }
+
+    /**
+     * Creates a class loader for an application that declares an extension of its own.
+     */
+    private ClassLoader createApplicationClassLoader() throws IOException {
+        Path metaInfPath = Files.createDirectories(applicationPath.resolve("META-INF"));
+        try (PrintWriter writer = new PrintWriter(metaInfPath.resolve("extensions.idx").toFile())) {
+            writer.println("# Generated by PF4J");
+            writer.println("org.pf4j.test.ApplicationExtension");
+        }
+
+        URL[] urls = { applicationPath.toUri().toURL() };
+
+        return new URLClassLoader(urls, getClass().getClassLoader());
+    }
+
+}

--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -351,15 +351,19 @@ class PluginClassLoaderTest {
         assertNumberOfResourcesAndFirstLineOfFirstElement(3, "parent", resources);
     }
 
+    /**
+     * The extensions index is resolved with the configured strategy, like any other resource.
+     * The finder reads the index of a plugin from the plugin itself.
+     */
     @Test
     void parentFirstGetExtensionsIndexExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
-        URL resource = parentFirstPluginClassLoader.getResource(LegacyExtensionFinder.EXTENSIONS_RESOURCE);
-        assertFirstLine("plugin", resource);
+        URL resource = parentFirstPluginClassLoader.getResource(IndexedExtensionFinder.EXTENSIONS_RESOURCE);
+        assertFirstLine("parent", resource);
     }
 
     @Test
     void parentLastGetExtensionsIndexExistsInParentAndDependencyAndPlugin() throws URISyntaxException, IOException {
-        URL resource = parentLastPluginClassLoader.getResource(LegacyExtensionFinder.EXTENSIONS_RESOURCE);
+        URL resource = parentLastPluginClassLoader.getResource(IndexedExtensionFinder.EXTENSIONS_RESOURCE);
         assertFirstLine("plugin", resource);
     }
 

--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -33,6 +33,7 @@ import java.io.PrintWriter;
 import java.lang.ref.WeakReference;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -362,6 +363,34 @@ class PluginClassLoaderTest {
         assertFirstLine("plugin", resource);
     }
 
+    /**
+     * A {@link PluginLoader} is free to return any class loader, so a dependency is not necessarily
+     * loaded with a {@link PluginClassLoader}.
+     */
+    @Test
+    void getResourceFromDependencyLoadedWithAnotherClassLoader() throws URISyntaxException, IOException {
+        pluginManager.addClassLoader("myDependency", createForeignDependencyClassLoader());
+
+        URL resource = parentLastPluginClassLoader.getResource("META-INF/file-only-in-foreign-dependency");
+        assertFirstLine("dependency", resource);
+    }
+
+    @Test
+    void getResourcesFromDependencyLoadedWithAnotherClassLoader() throws URISyntaxException, IOException {
+        pluginManager.addClassLoader("myDependency", createForeignDependencyClassLoader());
+
+        Enumeration<URL> resources = parentLastPluginClassLoader.getResources("META-INF/file-only-in-foreign-dependency");
+        assertNumberOfResourcesAndFirstLineOfFirstElement(1, "dependency", resources);
+    }
+
+    private ClassLoader createForeignDependencyClassLoader() throws IOException {
+        Path classesPath = pluginsPath.resolve("foreign-dependency");
+        Path metaInfPath = Files.createDirectories(classesPath.resolve("META-INF"));
+        Files.write(metaInfPath.resolve("file-only-in-foreign-dependency"), Collections.singletonList("dependency"));
+
+        return new URLClassLoader(new URL[] { classesPath.toUri().toURL() }, null);
+    }
+
     @Test
     void isClosed() throws IOException {
         parentLastPluginClassLoader.close();
@@ -465,7 +494,7 @@ class PluginClassLoaderTest {
             super(pluginsPath);
         }
 
-        void addClassLoader(String pluginId, PluginClassLoader classLoader) {
+        void addClassLoader(String pluginId, ClassLoader classLoader) {
             getPluginClassLoaders().put(pluginId, classLoader);
         }
 

--- a/pf4j/src/test/java/org/pf4j/ServiceProviderExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/ServiceProviderExtensionFinderTest.java
@@ -80,7 +80,7 @@ class ServiceProviderExtensionFinderTest {
         ServiceProviderExtensionFinder finder = new ServiceProviderExtensionFinder(pluginManager) {
 
             @Override
-            Enumeration<URL> findExtensionResource(PluginClassLoader classLoader) throws IOException {
+            protected Enumeration<URL> findStorageResources(ClassLoader classLoader, String name) throws IOException {
                 return getExtensionEnumeration();
             }
 


### PR DESCRIPTION
`PluginClassLoader` forced `PAD` when the requested resource was `extensions.idx`, so `getResource` disagreed with the configured strategy. The override is gone and `IndexedExtensionFinder` now asks the plugin class loader for its own resources, the way `ServiceProviderExtensionFinder` already did.

Both finders reach for the same thing, so the lookup moved to `AbstractExtensionFinder.findStorageResources`. That also closes #676, the cast to `PluginClassLoader` that threw a `ClassCastException` for a plugin loaded with another class loader. The same cast was in the two dependency lookups of `PluginClassLoader`, they are gone as well.

Reading the plugin instead of the strategy chain fixes a second thing: a plugin without an index of its own no longer inherits the extensions of its dependencies or of the application. With the default `PDA` strategy, a plugin depending on another one and declaring nothing itself was reported as declaring the extensions of that dependency, so `getExtensions` returned them twice.

Checked each fix against a red test first:

- the plugin index test finds `org.pf4j.test.ApplicationExtension` instead of the extension of the plugin, the symptom from #449
- `plugin-b` is reported with the extension of `plugin-a`
- both dependency lookups throw `ClassCastException: class java.net.URLClassLoader cannot be cast to class org.pf4j.PluginClassLoader`

`parentFirstGetExtensionsIndexExistsInParentAndDependencyAndPlugin` now expects the application copy. Without the override, `APD` resolving the index to the application is correct, and the assertion that matters moved to the finder.