### PR TITLE
Document PluginManager.getExtensions instantiation #293

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#673]: Read the extensions index of a plugin from every jar on the plugin classpath
 
 #### Added
+- [#293]: Document when `PluginManager.getExtensions` creates instances and what it returns
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,6 +653,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [#297]: https://github.com/pf4j/pf4j/issues/297
 [#296]: https://github.com/pf4j/pf4j/issues/296
 [#294]: https://github.com/pf4j/pf4j/issues/294
+[#293]: https://github.com/pf4j/pf4j/issues/293
 [#292]: https://github.com/pf4j/pf4j/issues/292
 [#288]: https://github.com/pf4j/pf4j/pull/288
 [#287]: https://github.com/pf4j/pf4j/pull/287

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -713,16 +713,42 @@ public abstract class AbstractPluginManager implements PluginManager {
         return getExtensionClasses(extensionFinder.find(type, pluginId));
     }
 
+    /**
+     * Returns extension instances of the given type from the application classpath
+     * and from every plugin that is in the {@link PluginState#STARTED} state.
+     * <p>
+     * Instances are created when this method is called, not when a plugin is loaded
+     * or started. {@link DefaultExtensionFactory} (the {@link DefaultPluginManager}
+     * default) constructs a new instance on every call;
+     * {@link SingletonExtensionFactory} returns the same instance for a given
+     * extension class. Instantiation failures are logged and omitted from the result.
+     */
     @Override
     public <T> List<T> getExtensions(Class<T> type) {
         return getExtensions(extensionFinder.find(type));
     }
 
+    /**
+     * Returns extension instances of the given type contributed by {@code pluginId}.
+     * <p>
+     * For a plugin id, the plugin must be {@link PluginState#STARTED}; a plugin that
+     * is only loaded contributes nothing. Instantiation follows the same
+     * {@link ExtensionFactory} rules as {@link #getExtensions(Class)}, including
+     * logging and omitting failures.
+     */
     @Override
     public <T> List<T> getExtensions(Class<T> type, String pluginId) {
         return getExtensions(extensionFinder.find(type, pluginId));
     }
 
+    /**
+     * Returns all extension instances contributed by {@code pluginId}.
+     * <p>
+     * For a plugin id, the plugin must be {@link PluginState#STARTED}; a plugin that
+     * is only loaded contributes nothing. Instantiation follows the same
+     * {@link ExtensionFactory} rules as {@link #getExtensions(Class)}, including
+     * logging and omitting failures.
+     */
     @Override
     @SuppressWarnings("unchecked")
     public List getExtensions(String pluginId) {

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -161,17 +161,12 @@ public interface PluginManager {
     <T> List<Class<? extends T>> getExtensionClasses(Class<T> type, String pluginId);
 
     /**
-     * Returns extension instances of the given type from the application classpath
-     * and from every plugin that is in the {@link PluginState#STARTED} state.
+     * Returns extension instances of the given type.
      * <p>
-     * Instances are created when this method is called, not when a plugin is loaded
-     * or started. The {@link ExtensionFactory} decides identity:
-     * {@link DefaultExtensionFactory} (the {@link DefaultPluginManager} default)
-     * constructs a new instance on every call; {@link SingletonExtensionFactory}
-     * returns the same instance for a given extension class.
-     * <p>
-     * Returns an empty list when no extension of {@code type} is registered.
-     * Instantiation failures are logged and omitted from the result.
+     * The result is never {@code null}. An empty list is returned when no
+     * extension of {@code type} is registered. Instances come from the
+     * {@link ExtensionFactory}, which decides whether they are shared or
+     * created per call.
      *
      * @param type the extension point
      * @param <T> the extension point type
@@ -185,11 +180,10 @@ public interface PluginManager {
      * Returns extension instances of the given type contributed by {@code pluginId}.
      * <p>
      * Pass {@code null} to retrieve extensions declared on the application classpath.
-     * For a plugin id, the plugin must be {@link PluginState#STARTED}; a plugin that
-     * is only loaded, an unknown id, or a type with no matching extensions yields
-     * an empty list rather than an exception.
-     * Instantiation follows the same {@link ExtensionFactory} rules as
-     * {@link #getExtensions(Class)}.
+     * An unknown id or a type with no matching extensions yields an empty list
+     * rather than an exception. The result is never {@code null}.
+     * Instances come from the {@link ExtensionFactory}, which decides whether
+     * they are shared or created per call.
      *
      * @param type the extension point
      * @param pluginId the plugin id, or {@code null} for classpath extensions
@@ -202,10 +196,10 @@ public interface PluginManager {
      * Returns all extension instances contributed by {@code pluginId}.
      * <p>
      * Pass {@code null} to retrieve extensions declared on the application classpath.
-     * For a plugin id, the plugin must be {@link PluginState#STARTED}; a plugin that
-     * is only loaded or an unknown id yields an empty list rather than an exception.
-     * Instantiation follows the same {@link ExtensionFactory} rules as
-     * {@link #getExtensions(Class)}.
+     * An unknown id yields an empty list rather than an exception.
+     * The result is never {@code null}. Instances come from the
+     * {@link ExtensionFactory}, which decides whether they are shared or
+     * created per call.
      *
      * @param pluginId the plugin id, or {@code null} for classpath extensions
      * @return the extensions for the plugin, never {@code null}

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -160,15 +160,55 @@ public interface PluginManager {
 
     <T> List<Class<? extends T>> getExtensionClasses(Class<T> type, String pluginId);
 
+    /**
+     * Returns extension instances of the given type from the application classpath
+     * and from every plugin that is in the {@link PluginState#STARTED} state.
+     * <p>
+     * Instances are created when this method is called, not when a plugin is loaded
+     * or started. The {@link ExtensionFactory} decides identity:
+     * {@link DefaultExtensionFactory} (the {@link DefaultPluginManager} default)
+     * constructs a new instance on every call; {@link SingletonExtensionFactory}
+     * returns the same instance for a given extension class.
+     * <p>
+     * Returns an empty list when no extension of {@code type} is registered.
+     * Instantiation failures are logged and omitted from the result.
+     *
+     * @param type the extension point
+     * @param <T> the extension point type
+     * @return matching instances, never {@code null}
+     * @see #getExtensions(Class, String)
+     * @see ExtensionFactory
+     */
     <T> List<T> getExtensions(Class<T> type);
 
+    /**
+     * Returns extension instances of the given type contributed by {@code pluginId}.
+     * <p>
+     * Pass {@code null} to retrieve extensions declared on the application classpath.
+     * For a plugin id, the plugin must be {@link PluginState#STARTED}; a plugin that
+     * is only loaded, an unknown id, or a type with no matching extensions yields
+     * an empty list rather than an exception.
+     * Instantiation follows the same {@link ExtensionFactory} rules as
+     * {@link #getExtensions(Class)}.
+     *
+     * @param type the extension point
+     * @param pluginId the plugin id, or {@code null} for classpath extensions
+     * @param <T> the extension point type
+     * @return matching instances, never {@code null}
+     */
     <T> List<T> getExtensions(Class<T> type, String pluginId);
 
     /**
-     * Retrieves the extensions for the specified plugin.
+     * Returns all extension instances contributed by {@code pluginId}.
+     * <p>
+     * Pass {@code null} to retrieve extensions declared on the application classpath.
+     * For a plugin id, the plugin must be {@link PluginState#STARTED}; a plugin that
+     * is only loaded or an unknown id yields an empty list rather than an exception.
+     * Instantiation follows the same {@link ExtensionFactory} rules as
+     * {@link #getExtensions(Class)}.
      *
-     * @param pluginId the unique plugin identifier, specified in its metadata
-     * @return the extensions for the plugin
+     * @param pluginId the plugin id, or {@code null} for classpath extensions
+     * @return the extensions for the plugin, never {@code null}
      */
     List getExtensions(String pluginId);
 


### PR DESCRIPTION
The getExtensions methods on PluginManager had almost no API docs.

I documented the current DefaultPluginManager / AbstractExtensionFinder behavior:

- instances are created on getExtensions, not at load/start
- only STARTED plugins contribute (null pluginId is the application classpath)
- DefaultExtensionFactory makes a new instance each call; SingletonExtensionFactory reuses
- unknown plugin id or missing type returns an empty list

Fixes #293
