### PR TITLE
Load generated classes on demand instead of sorting them (fixes #677)

### DIFF
--- a/pf4j/src/test/java/org/pf4j/test/JavaFileObjectClassLoader.java
+++ b/pf4j/src/test/java/org/pf4j/test/JavaFileObjectClassLoader.java
@@ -18,8 +18,8 @@ package org.pf4j.test;
 import javax.tools.JavaFileObject;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,6 +32,8 @@ import java.util.Objects;
  */
 public class JavaFileObjectClassLoader extends ClassLoader {
 
+    private final Map<String, byte[]> classes = new HashMap<>();
+
     public Map<String, Class<?>> load(JavaFileObject... objects) {
         return load(Arrays.asList(objects));
     }
@@ -40,9 +42,6 @@ public class JavaFileObjectClassLoader extends ClassLoader {
         Objects.requireNonNull(objects);
 
         List<JavaFileObject> mutableObjects = new ArrayList<>(objects);
-
-        // Sort generated ".class" by lastModified field
-        mutableObjects.sort(Comparator.comparingLong(JavaFileObject::getLastModified));
 
         // Compile Java sources (if exists)
         for (int i = 0; i < mutableObjects.size(); i++) {
@@ -58,16 +57,52 @@ public class JavaFileObjectClassLoader extends ClassLoader {
             }
         }
 
+        // Keep the bytes of every class before defining any of them, a class is defined on demand
+        for (JavaFileObject object : mutableObjects) {
+            classes.put(JavaFileObjectUtils.getClassName(object), JavaFileObjectUtils.getAllBytes(object));
+        }
+
         // Load objects
-        Map<String, Class<?>> loadedClasses = new HashMap<>();
+        Map<String, Class<?>> loadedClasses = new LinkedHashMap<>();
         for (JavaFileObject object : mutableObjects) {
             String className = JavaFileObjectUtils.getClassName(object);
-            byte[] data = JavaFileObjectUtils.getAllBytes(object);
-            Class<?> loadedClass = defineClass(className, data, 0, data.length);
-            loadedClasses.put(className, loadedClass);
+            loadedClasses.put(className, loadGeneratedClass(className));
         }
 
         return loadedClasses;
+    }
+
+    /**
+     * Defines a class from the bytes collected by {@link #load}.
+     * <p>
+     * A class is defined when it is first asked for, either by {@link #load} or by the virtual machine
+     * while it resolves the super types of another class, so the order of the objects does not matter.
+     *
+     * @param name the name of the class
+     * @return the loaded class
+     * @throws ClassNotFoundException if the class was not given to {@link #load}
+     */
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        byte[] data = classes.remove(name);
+        if (data == null) {
+            throw new ClassNotFoundException(name);
+        }
+
+        return defineClass(name, data, 0, data.length);
+    }
+
+    private Class<?> loadGeneratedClass(String className) {
+        Class<?> loadedClass = findLoadedClass(className);
+        if (loadedClass != null) {
+            return loadedClass;
+        }
+
+        try {
+            return findClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
 }

--- a/pf4j/src/test/java/org/pf4j/test/JavaFileObjectClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/test/JavaFileObjectClassLoaderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2012-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.test;
+
+import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaFileObject;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Decebal Suiu
+ */
+class JavaFileObjectClassLoaderTest {
+
+    /**
+     * {@code WhazzupGreeting} implements {@code Greeting}, so defining it makes the virtual machine
+     * ask for the interface. The class loader has to answer that on its own, whatever the order of
+     * the objects is.
+     */
+    @Test
+    void loadsClassesInAnyOrder() {
+        List<JavaFileObject> generatedFiles = new ArrayList<>(
+            JavaSources.compileAll(JavaSources.GREETING, JavaSources.WHAZZUP_GREETING));
+
+        // put the implementation before the interface, whatever the compiler emitted
+        generatedFiles.sort(Comparator.comparingInt(
+            object -> JavaSources.GREETING_CLASS_NAME.equals(JavaFileObjectUtils.getClassName(object)) ? 1 : 0));
+
+        Map<String, Class<?>> loadedClasses = new JavaFileObjectClassLoader().load(generatedFiles);
+
+        assertEquals(2, loadedClasses.size());
+
+        Class<?> greetingClass = loadedClasses.get(JavaSources.GREETING_CLASS_NAME);
+        Class<?> whazzupGreetingClass = loadedClasses.get(JavaSources.WHAZZUP_GREETING_CLASS_NAME);
+        assertNotNull(greetingClass);
+        assertNotNull(whazzupGreetingClass);
+        assertTrue(greetingClass.isAssignableFrom(whazzupGreetingClass));
+    }
+
+}


### PR DESCRIPTION
`JavaFileObjectClassLoader` defined every generated class eagerly, in a list sorted by `getLastModified`. The sort was an attempt to define a super type before the class that needs it, because defining a class makes the virtual machine resolve its super types through the defining loader, and this loader had no `findClass` of its own. Two classes compiled in the same millisecond tie, the order is then whatever the compiler emitted, and `AbstractExtensionFinderTest` fails with `NoClassDefFoundError: test/Greeting`.

The loader now keeps the bytes and defines a class the first time it is asked for, either by `load` or by the virtual machine while it resolves a super type, so the order of the objects stops mattering and the sort is gone.

`load` resolves through `findLoadedClass` and `findClass` rather than `loadClass`, so a generated class still wins over a class of the same name on the parent classpath, as before.

Reproduced the flake first by stamping the objects so the implementation sorts before the interface, which fails on the old loader and passes on the new one. The test that stays behind puts the implementation first and fails with the same `NoClassDefFoundError` on an implementation that defines eagerly.