### PR TITLE
Skip a dependency whose class loader is missing (fixes #679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#670]: Read the `ordinal` attribute of the `Extension` annotation via ASM
 - [#673]: Do not report the extensions of a dependency or of the application as extensions of a plugin
 - [#676]: Read the extensions of a plugin loaded with a custom class loader without a `ClassCastException`
+- [#679]: Skip a dependency whose class loader is missing instead of throwing a `NullPointerException`
 
 #### Changed
 - [#673]: Read the extensions index of a plugin from every jar on the plugin classpath
@@ -564,6 +565,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.11.0]: https://github.com/decebals/pf4j/compare/release-0.10.0...release-0.11.0
 [0.10.0]: https://github.com/decebals/pf4j/compare/release-0.9.0...release-0.10.0
 
+[#679]: https://github.com/pf4j/pf4j/issues/679
 [#676]: https://github.com/pf4j/pf4j/issues/676
 [#673]: https://github.com/pf4j/pf4j/issues/673
 [#670]: https://github.com/pf4j/pf4j/issues/670

--- a/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/org/pf4j/PluginClassLoader.java
@@ -269,6 +269,30 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     /**
+     * Returns the class loader of a dependency of the plugin.
+     * <p>
+     * The class loader is missing when an optional dependency is not installed, which is expected, and
+     * when a dependency was unloaded or disabled while this plugin stayed loaded, which is not.
+     *
+     * @param dependency the dependency of the plugin
+     * @return the class loader of the dependency, {@code null} if it is not available
+     */
+    protected ClassLoader getDependencyClassLoader(PluginDependency dependency) {
+        ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
+        if (classLoader == null) {
+            if (dependency.isOptional()) {
+                log.debug("Cannot find the class loader of the optional dependency '{}' of plugin '{}'",
+                    dependency.getPluginId(), pluginDescriptor.getPluginId());
+            } else {
+                log.warn("Cannot find the class loader of the dependency '{}' of plugin '{}'",
+                    dependency.getPluginId(), pluginDescriptor.getPluginId());
+            }
+        }
+
+        return classLoader;
+    }
+
+    /**
      * Loads the class with the specified name from the dependencies of the plugin.
      *
      * @param className the name of the class
@@ -278,10 +302,8 @@ public class PluginClassLoader extends URLClassLoader {
         log.trace("Search in dependencies for class '{}'", className);
         List<PluginDependency> dependencies = pluginDescriptor.getDependencies();
         for (PluginDependency dependency : dependencies) {
-            ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
-
-            // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null && dependency.isOptional()) {
+            ClassLoader classLoader = getDependencyClassLoader(dependency);
+            if (classLoader == null) {
                 continue;
             }
 
@@ -305,10 +327,8 @@ public class PluginClassLoader extends URLClassLoader {
         log.trace("Search in dependencies for resource '{}'", name);
         List<PluginDependency> dependencies = pluginDescriptor.getDependencies();
         for (PluginDependency dependency : dependencies) {
-            ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
-
-            // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null && dependency.isOptional()) {
+            ClassLoader classLoader = getDependencyClassLoader(dependency);
+            if (classLoader == null) {
                 continue;
             }
 
@@ -335,10 +355,8 @@ public class PluginClassLoader extends URLClassLoader {
         List<URL> results = new ArrayList<>();
         List<PluginDependency> dependencies = pluginDescriptor.getDependencies();
         for (PluginDependency dependency : dependencies) {
-            ClassLoader classLoader = pluginManager.getPluginClassLoader(dependency.getPluginId());
-
-            // If the dependency is marked as optional, its class loader might not be available.
-            if (classLoader == null && dependency.isOptional()) {
+            ClassLoader classLoader = getDependencyClassLoader(dependency);
+            if (classLoader == null) {
                 continue;
             }
 

--- a/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
+++ b/pf4j/src/test/java/org/pf4j/PluginClassLoaderTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -393,6 +394,36 @@ class PluginClassLoaderTest {
         Files.write(metaInfPath.resolve("file-only-in-foreign-dependency"), Collections.singletonList("dependency"));
 
         return new URLClassLoader(new URL[] { classesPath.toUri().toURL() }, null);
+    }
+
+    /**
+     * A required dependency has no class loader when it was unloaded while this plugin stayed loaded.
+     * A lookup returns nothing, the same as for an optional dependency that is not installed.
+     */
+    @Test
+    void getResourceWhenTheClassLoaderOfARequiredDependencyIsMissing() throws IOException {
+        PluginClassLoader classLoader = createClassLoaderWithMissingDependency();
+
+        assertNull(classLoader.getResource("META-INF/file-only-in-dependency"));
+        assertFalse(classLoader.getResources("META-INF/file-only-in-dependency").hasMoreElements());
+    }
+
+    @Test
+    void loadClassWhenTheClassLoaderOfARequiredDependencyIsMissing() {
+        PluginClassLoader classLoader = createClassLoaderWithMissingDependency();
+
+        assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass("test.Missing"));
+    }
+
+    private PluginClassLoader createClassLoaderWithMissingDependency() {
+        DefaultPluginDescriptor descriptor = new DefaultPluginDescriptor()
+            .setPluginId("myPluginWithMissingDependency")
+            .setPluginVersion("1.2.3")
+            .setDependencies("missingDependency")
+            .setProvider("Me")
+            .setRequires("5.0.0");
+
+        return new PluginClassLoader(pluginManager, descriptor, PluginClassLoaderTest.class.getClassLoader());
     }
 
     @Test


### PR DESCRIPTION
Fixes #679.

The three lookups through the dependencies of a plugin only skipped a dependency without a class loader when it was optional. For a required one they fell through and dereferenced null, so a lookup ended with a `NullPointerException` naming nothing.

They now skip either way and log which dependency of which plugin is missing, `debug` for an optional one because that is expected, `warn` for a required one because the application is in a state it should not be in. Throwing would have been the other option, but these methods are lookups that return null or nothing when they find nothing, and `getResource` is documented to do exactly that. Deciding whether a plugin may run belongs to the dependency resolver, not to a resource lookup.

The lookup moved to `getDependencyClassLoader`, the same six lines were written three times and the fix would have been a third copy of the condition. It stays `protected` because the three methods around it are overridable, so a subclass that replaces one of them can still reuse it.

On master both tests fail with the `NullPointerException`, one from `getResource` and one from `loadClass` where the expected `ClassNotFoundException` never gets a chance to be thrown.