### PR TITLE
Warn when the storage of a plugin cannot be read in isolation (fixes #684)

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
@@ -66,9 +66,15 @@ public abstract class AbstractExtensionFinder implements ExtensionFinder, Plugin
      * @throws IOException if I/O errors occur
      */
     protected Enumeration<URL> findStorageResources(ClassLoader classLoader, String name) throws IOException {
-        return classLoader instanceof URLClassLoader
-            ? ((URLClassLoader) classLoader).findResources(name)
-            : classLoader.getResources(name);
+        if (classLoader instanceof URLClassLoader) {
+            return ((URLClassLoader) classLoader).findResources(name);
+        }
+
+        log.warn("Cannot read '{}' from the plugin alone, '{}' is not a URLClassLoader."
+            + " The extensions declared by the application may be reported as extensions of the plugin",
+            name, classLoader.getClass().getName());
+
+        return classLoader.getResources(name);
     }
 
     @Override

--- a/pf4j/src/test/java/org/pf4j/IndexedExtensionFinderTest.java
+++ b/pf4j/src/test/java/org/pf4j/IndexedExtensionFinderTest.java
@@ -28,6 +28,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,6 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 public class IndexedExtensionFinderTest {
 
@@ -114,6 +116,28 @@ public class IndexedExtensionFinderTest {
 
         assertThat(pluginsStorages.get("plugin-a"), contains(TestExtension.class.getName()));
         assertEquals(Collections.emptySet(), pluginsStorages.get("plugin-b"));
+    }
+
+    /**
+     * A plugin loaded with a class loader that is not a {@link java.net.URLClassLoader} cannot be
+     * searched in isolation, the storage is then whatever that class loader makes visible.
+     */
+    @Test
+    public void shouldReadTheStorageOfAPluginLoadedWithAnotherClassLoader() throws Exception {
+        URL url = applicationPath.toUri().toURL();
+        ClassLoader classLoader = new ClassLoader(null) {
+
+            @Override
+            public Enumeration<URL> getResources(String name) {
+                return Collections.enumeration(Collections.singletonList(url));
+            }
+
+        };
+
+        IndexedExtensionFinder extensionFinder = new IndexedExtensionFinder(mock(PluginManager.class));
+        Enumeration<URL> urls = extensionFinder.findStorageResources(classLoader, IndexedExtensionFinder.EXTENSIONS_RESOURCE);
+
+        assertEquals(Collections.singletonList(url), Collections.list(urls));
     }
 
     /**


### PR DESCRIPTION
Fixes #684.

`findStorageResources` falls back to `getResources` for a class loader that is not a `URLClassLoader`, which consults the parent and brings back the behaviour from #449, the extensions of the application reported as extensions of the plugin. The fallback was silent, so someone using such a plugin loader had a wrong extension list and nothing to go on.

It now logs which resource and which class loader, so the situation can be recognised and reported. Nothing else changes, #680 is what removes the fallback.

The two dependency lookups of `PluginClassLoader` have the same fallback and are deliberately left alone: there it only widens a lookup that is best effort anyway, and it runs for every resource, so a warning would be noise.

The branch had no test, and this restructures it from a ternary into a return, so there is one now. Asserting on the log message itself is not worth it, `slf4j-simple` writes to `System.err` and offers nothing to capture with.