### PR TITLE
Document when PluginManager.unloadPlugin returns false #291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Added
 - [#293]: Document when `PluginManager.getExtensions` creates instances and what it returns
+- [#291]: Document when `PluginManager.unloadPlugin` returns `false` and what callers can do
 
 #### Removed
 
@@ -657,6 +658,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [#294]: https://github.com/pf4j/pf4j/issues/294
 [#293]: https://github.com/pf4j/pf4j/issues/293
 [#292]: https://github.com/pf4j/pf4j/issues/292
+[#291]: https://github.com/pf4j/pf4j/issues/291
 [#288]: https://github.com/pf4j/pf4j/pull/288
 [#287]: https://github.com/pf4j/pf4j/pull/287
 [#278]: https://github.com/pf4j/pf4j/pull/278

--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -263,10 +263,7 @@ public abstract class AbstractPluginManager implements PluginManager {
     }
 
     /**
-     * Unload the specified plugin and it's dependents.
-     *
-     * @param pluginId the pluginId of the plugin to unload
-     * @return true if the plugin was unloaded, otherwise false
+     * {@inheritDoc}
      */
     @Override
     public boolean unloadPlugin(String pluginId) {

--- a/pf4j/src/main/java/org/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/PluginManager.java
@@ -112,10 +112,23 @@ public interface PluginManager {
 
     /**
      * Unload a plugin.
+     * <p>
+     * Dependents are unloaded first. Returns {@code false} if the plugin is
+     * not loaded (unknown id or already unloaded). That is not an error; treat
+     * it as a no-op. Also returns {@code false} if the plugin could not be
+     * stopped and is still {@link PluginState#STARTED}; it remains loaded in
+     * that case. Inspect {@link PluginWrapper#getFailedException()} and retry
+     * after the plugin can be stopped.
+     * <p>
+     * {@link Plugin#stop()} throwing {@link PluginRuntimeException} does not
+     * fail the unload: the plugin is still removed and this method returns
+     * {@code true}. The exception is stored on the wrapper.
      *
      * @param pluginId the unique plugin identifier, specified in its metadata
-     * @return true if the plugin was unloaded
-     * @throws PluginRuntimeException if something goes wrong
+     * @return {@code true} if the plugin was unloaded, {@code false} if it was
+     *         not loaded or could not be stopped
+     * @throws PluginRuntimeException if the plugin classloader cannot be closed
+     * @see PluginWrapper#getFailedException()
      */
     boolean unloadPlugin(String pluginId);
 


### PR DESCRIPTION
unloadPlugin's javadoc only said it returns true if the plugin was unloaded.

I documented the current AbstractPluginManager behavior:

- false when the id is unknown or already unloaded (not an error)
- false when stop leaves the plugin STARTED; it stays loaded
- Plugin.stop throwing PluginRuntimeException still unloads and returns true; the cause is on PluginWrapper.getFailedException()
- PluginRuntimeException is thrown if the plugin classloader cannot be closed

Fixes #291